### PR TITLE
added api URLs to test manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,5 +25,7 @@ applications:
     - route: assessment.test.fundingservice.co.uk
   env:
     FLASK_ENV: test
+    ASSESSMENT_STORE_API_HOST: https://funding-service-design-assessment-store-test.london.cloudapps.digital
+    FUND_STORE_API_HOST: https://funding-service-design-fund-store-test.london.cloudapps.digital
   health-check-http-endpoint: /healthcheck
   health-check-type: http


### PR DESCRIPTION
Assessment was borken on test after last merge as the test manifest didn't contain the URLs for fund_store or assessment_store. This adds them