### PR TITLE
FS-2045: Add assessment domain routes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ applications:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
   routes:
-    - route: assessment.dev.fundingservice.co.uk
+    - route: assessment.dev.gids.dev
   env:
     FLASK_ENV: dev
     FLASK_DEBUG: 1
@@ -22,7 +22,7 @@ applications:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
   routes:
-    - route: assessment.test.fundingservice.co.uk
+    - route: assessment.test.gids.dev
   env:
     FLASK_ENV: test
     ASSESSMENT_STORE_API_HOST: https://funding-service-design-assessment-store-test.london.cloudapps.digital


### PR DESCRIPTION
Add assessment routes (this is important to be able to test authentication and other functionality which depends on a shared domain)