### PR TITLE
BAU: Add functionality to switch auth user roles in development via config var

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -28,7 +28,11 @@ def auth_protect(minimum_roles_required, unprotected_routes):
 
     """
 
-    if Config.FLASK_ENV == "development" and Config.DEBUG_USER_ROLE:
+    if (
+        Config.FLASK_ENV == "development"
+        and Config.DEBUG_USER_ROLE
+        and not g.is_authenticated
+    ):
         g.is_authenticated = True
         g.account_id = "dev-account-id"
         g.user = User(**Config.DEBUG_USER)

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,59 @@
+from config import Config
+from flask import g
+from flask import redirect
+from flask import request
+from fsd_utils.authentication.models import User
+
+
+def auth_protect(minimum_roles_required, unprotected_routes):
+    """
+    Checks the authentication and authorisation attributes of the
+    user accessing the service and allows them to access the requested
+    resource if authorised, or redirect them to login (or a permissions
+    error message) if not authenticated/authorised.
+
+    The function also incorporates support for bypassing authorisation
+    via setting of a DEBUG_USER_ROLE env var which will mimic the effect
+    of a user with that role (only used when FLASK_ENV is "development").
+
+    Args:
+        minimum_roles_required: List[str]
+            - a list of minimum roles a user must have to access the service
+        unprotected_routes: List[str]
+            - a list of routes e.g. ["/"]
+                that can be accessed without authentication
+
+    Returns:
+        redirect (302) or None if authorised
+
+    """
+
+    if Config.FLASK_ENV == "development" and Config.DEBUG_USER_ROLE:
+        g.is_authenticated = True
+        g.account_id = "dev-account-id"
+        g.user = User(**Config.DEBUG_USER)
+        if request.path in ["", "/"]:
+            return redirect(Config.DASHBOARD_ROUTE)
+
+    elif g.is_authenticated:
+        # Ensure that authenticated users have
+        # all minimum required roles
+        if not g.user.roles or not all(
+            role_required in g.user.roles
+            for role_required in minimum_roles_required
+        ):
+            return redirect(
+                Config.AUTHENTICATOR_HOST
+                + "/service/user"
+                + "?roles_required="
+                + "|".join(minimum_roles_required)
+            )
+        elif request.path in ["", "/"]:
+            return redirect(Config.DASHBOARD_ROUTE)
+    elif (
+        request.path not in unprotected_routes
+        and not request.path.startswith("/static/")
+    ):  # noqa
+        # Redirect unauthenticated users to
+        # login on the home page
+        return redirect("/")

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -11,21 +11,28 @@ class DevelopmentConfig(DefaultConfig):
 
     # for local testing with flask run and USE_LOCAL_DATA = True:
     # USE_LOCAL_DATA = True
-    # FSD_LOG_LEVEL = logging.INFO
-    # FUND_STORE_API_HOST = "fund_store"
-    # ASSESSMENT_STORE_API_HOST = "assessment_store"
-    # APPLICATION_STORE_API_HOST = "application_store"
-
-    # FUND_STORE_API_HOST = "https://funding-service-design-fund-store-dev.london.cloudapps.digital" # noqa
-    # ASSESSMENT_STORE_API_HOST = "https://funding-service-design-assessment-store-dev.london.cloudapps.digital" # noqa
-
     # for testing with docker runner:
     USE_LOCAL_DATA = False
+
     FSD_LOG_LEVEL = logging.INFO
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
-    AUTHENTICATOR_HOST = getenv("AUTHENTICATOR_HOST", "authenticator")
+    AUTHENTICATOR_HOST = getenv("AUTHENTICATOR_HOST", "https://authenticator")
     SSO_LOGIN_URL = AUTHENTICATOR_HOST + "/sso/login"
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
+
+    DEBUG_USER_ROLE = getenv("DEBUG_USER_ROLE", "COMMENTER")
+
+    DEBUG_USER = {
+        "full_name": "Development User",
+        "email": "dev@example.com",
+        "roles": {
+            "LEAD_ASSESSOR": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+            "ASSESSOR": ["ASSESSOR", "COMMENTER"],
+            "COMMENTER": ["COMMENTER"],
+        }.get(DEBUG_USER_ROLE),
+        "highest_role": DEBUG_USER_ROLE,
+    }
+
     # RSA 256 KEYS
     RSA256_PUBLIC_KEY_BASE64 = getenv("RSA256_PUBLIC_KEY_BASE64")
     if RSA256_PUBLIC_KEY_BASE64:


### PR DESCRIPTION
### Add functionality to switch auth user roles in development, via DEBUG_USER_ROLE env var

- Refactor global auth functionality from create_app to new auth_protect() function
- Add DEBUG_USER_ROLE env var to development config (defaulting to "LEAD_ASSESSOR") 
- Add DEBUG_USER config var (in development config only) which creates a dict of user attributes with roles defined by DEBUG_USER_ROLE env var, to enable local development debugging of user roles