### PR TITLE
BAU: move S3 config into main config file

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -21,15 +21,6 @@ from flask import abort
 from flask import current_app
 from flask import g
 
-if "VCAP_SERVICES" in os.environ:
-    vcap_services = json.loads(os.environ["VCAP_SERVICES"])
-
-    if "aws-s3-bucket" in vcap_services:
-        s3_credentials = vcap_services["aws-s3-bucket"][0]["credentials"]
-        Config.AWS_ACCESS_KEY_ID = s3_credentials["aws_access_key_id"]
-        Config.AWS_SECRET_ACCESS_KEY = s3_credentials["aws_secret_access_key"]
-        Config.AWS_BUCKET_NAME = s3_credentials["bucket_name"]
-
 
 def get_data(
     endpoint: str,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,4 +1,6 @@
 import base64
+import json
+import os
 from os import environ
 from os import getenv
 from pathlib import Path
@@ -128,7 +130,12 @@ class DefaultConfig:
     Aws Config
     """
 
-    AWS_ACCESS_KEY_ID = getenv("AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY = getenv("AWS_SECRET_ACCESS_KEY")
-    AWS_BUCKET_NAME = getenv("AWS_BUCKET_NAME")
-    AWS_REGION = "eu-west-2"
+    if "VCAP_SERVICES" in os.environ:
+        vcap_services = json.loads(os.environ["VCAP_SERVICES"])
+
+        if "aws-s3-bucket" in vcap_services:
+            s3_credentials = vcap_services["aws-s3-bucket"][0]["credentials"]
+            AWS_REGION = s3_credentials["aws_region"]
+            AWS_ACCESS_KEY_ID = s3_credentials["aws_access_key_id"]
+            AWS_SECRET_ACCESS_KEY = s3_credentials["aws_secret_access_key"]
+            AWS_BUCKET_NAME = s3_credentials["bucket_name"]

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -58,3 +58,8 @@ class DevelopmentConfig(DefaultConfig):
         )
         with open(_test_public_key_path, mode="rb") as public_key_file:
             RSA256_PUBLIC_KEY = public_key_file.read()
+
+    AWS_ACCESS_KEY_ID = getenv("AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY = getenv("AWS_SECRET_ACCESS_KEY")
+    AWS_BUCKET_NAME = getenv("AWS_BUCKET_NAME")
+    AWS_REGION = "eu-west-2"

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -22,3 +22,7 @@ class UnitTestConfig(DefaultConfig):
         )
         with open(_test_public_key_path, mode="rb") as public_key_file:
             RSA256_PUBLIC_KEY = public_key_file.read()
+    AWS_ACCESS_KEY_ID = getenv("AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY = getenv("AWS_SECRET_ACCESS_KEY")
+    AWS_BUCKET_NAME = getenv("AWS_BUCKET_NAME")
+    AWS_REGION = "eu-west-2"

--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,8 @@ applications:
     GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http
+  services:
+    - form-uploads-dev
 
 - name: funding-service-design-assessment-test
   memory: 64M


### PR DESCRIPTION
Found in the course of another story. This S3 PaaS config was previously in `data.py` which made it difficult to reason about how S3 was configured. This moves it to the shared config.