### PR TITLE
Removing inline style

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -7,7 +7,7 @@
 
 {% block content %}
     <div class="govuk-phase-banner flex-parent-element">
-        <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right"><a href="{{ sso_logout_url }}" class="govuk-link flexed-element-margins-collapse" style="text-align:right !important;">Log out</a></p>
+        <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right"><a href="{{ sso_logout_url }}" class="govuk-link flexed-element-margins-collapse">Log out</a></p>
     </div>
     </div>
     <div class="fsd-banner-background">


### PR DESCRIPTION
Inline style removed to fix console errors, Link is already right aligned 