### PR TITLE
FIX: Allow /healthcheck route past auth

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -36,7 +36,7 @@ def auth_protect(minimum_roles_required, unprotected_routes):
         g.is_authenticated = True
         g.account_id = "dev-account-id"
         g.user = User(**Config.DEBUG_USER)
-        if request.path in ["", "/"]:
+        if request.path in ["/"]:
             return redirect(Config.DASHBOARD_ROUTE)
 
     elif g.is_authenticated:

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -15,8 +15,8 @@ from flask_assets import Environment
 from flask_compress import Compress
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
-from fsd_utils.authentication.decorators import login_requested
 from fsd_utils import init_sentry
+from fsd_utils.authentication.decorators import login_requested
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.logging import logging
@@ -123,7 +123,7 @@ def create_app() -> Flask:
         def ensure_minimum_required_roles():
             return auth_protect(
                 minimum_roles_required=["COMMENTER"],
-                unprotected_routes=["", "/"],
+                unprotected_routes=["/", "/healthcheck"],
             )
 
         @flask_app.after_request

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -260,6 +260,40 @@ class TestRoutes:
             " criteria scoring page"
         )
 
+    def test_homepage_route_accessible(self, flask_test_client):
+
+        # Remove fsd-user-token cookie
+        flask_test_client.set_cookie("localhost", "fsd_user_token", "")
+
+        # Send a request to the homepage "/" route
+        response = flask_test_client.get("/")
+
+        # Assert that the response has the expected status code
+        assert (
+            200 == response.status_code
+        ), "Homepage route should be accessible"
+
+        # Send a request to the root route
+        response = flask_test_client.get("", follow_redirects=True)
+
+        # Assert that the response has the expected status code
+        assert (
+            200 == response.status_code
+        ), "Homepage route should be accessible"
+
+    def test_healthcheck_route_accessible(self, flask_test_client):
+
+        # Remove fsd-user-token cookie
+        flask_test_client.set_cookie("localhost", "fsd_user_token", "")
+
+        # Send a request to the /healthcheck route
+        response = flask_test_client.get("/healthcheck")  # noqa
+
+        # Assert that the response has the expected status code
+        assert (
+            200 == response.status_code
+        ), "Healthcheck route should be accessible"
+
     @pytest.mark.parametrize(
         "expected_ids, expected_names",
         [


### PR DESCRIPTION
### Allow /healthcheck route past auth

- Update unprotected_routes list to include /healthcheck route and remove empty route.
- Add tests to ensure homepage routes and /healthcheck route are accessible