### PR TITLE
BAU: Fix typo in route, remove unnecessary closing div

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -57,7 +57,7 @@ def display_sub_criteria(
         "application_id": application_id,
         "fund": fund,
         "comments": comments,
-        "if_flagged": is_flagged,
+        "is_flagged": is_flagged,
     }
 
     if theme_id == "score":

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -12,9 +12,8 @@
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">{{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}</p>
         <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right"><a href="{{ sso_logout_url }}" class="govuk-link flexed-element-margins-collapse">Log out</a></p>
     </div>
-    </div>
 
-    {% if flag %}
+     {% if flag %}
         {{ assessment_flag(flag, flag_user_info) }}
     {% endif %}
 

--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -6,8 +6,7 @@
         <p class="govuk-body">{{ flag.justification }}</p>
         <h2 class="govuk-heading-m">Section flagged</h2>
         <p class="govuk-body">{{ flag.section_to_flag }}</p>
-        {# TODO: Add lead role or highest role dynamically here? #}
-        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] }}) {{ user_info["email_address"] }}</p>
+        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | datetime_format("%d/%m/%Y at %H:%M") }}</p>
     </div>
 {% endmacro %}


### PR DESCRIPTION
Quick fix for the following type things:

- Extra `</div>` causing styling errors on UAT
- Typo causing "Flag application" button to show on UAT when there is already a flag
- Fix styling of role badge on flag banner (LEAD_ASSESSOR -> Lead assessor)

https://assessment.uat.gids.dev/assess/application/b823cf41-e8b7-4556-8265-692b3ee992f9

Screenshots of before: (broken styling & wrong "flag application" button)
![image](https://user-images.githubusercontent.com/117724519/210828495-914a11c9-9c88-4407-803e-62fd1941c05b.png)
![image](https://user-images.githubusercontent.com/117724519/210828551-f9b0a7b6-5a63-4282-90ff-c457ceb4ffee.png)

Screenshots of after: (fixed styling & no "flag application" button)
![image](https://user-images.githubusercontent.com/117724519/210829444-ff68b26c-f442-45b9-a4a6-526baa299358.png)
![image](https://user-images.githubusercontent.com/117724519/210828711-ed61260f-6119-4945-a102-460732bd473f.png)
