### PR TITLE
FS-2125, FS-2126, BAU: Anchors for comments, Flag application validation

### DIFF
--- a/app/assess/forms/flag_form.py
+++ b/app/assess/forms/flag_form.py
@@ -7,8 +7,18 @@ from wtforms.validators import length
 
 class FlagApplicationForm(FlaskForm):
     reason = TextAreaField(
-        "Reason for flagging", validators=[length(max=10000), DataRequired()]
+        "Reason for flagging",
+        validators=[
+            length(max=10000),
+            DataRequired(
+                message="Provide a reason for flagging this application"
+            ),
+        ],
     )
     section = StringField(
-        "Section to flag", validators=[length(max=10000), DataRequired()]
+        "Section to flag",
+        validators=[
+            length(max=10000),
+            DataRequired(message="Provide which section you are flagging"),
+        ],
     )

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -40,8 +40,53 @@ def display_sub_criteria(
     current_app.logger.info(f"Processing GET to {request.path}.")
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     theme_id = request.args.get("theme_id", sub_criteria.themes[0].id)
+    comment_form = CommentsForm()
+
+    add_comment_argument = request.args.get("add_comment") == "1"
+    if all(
+        [
+            add_comment_argument,
+            request.method == "POST",
+            comment_form.validate_on_submit(),
+        ]
+    ):
+        comment = comment_form.comment.data
+
+        submit_comment(
+            comment=comment,
+            application_id=application_id,
+            sub_criteria_id=sub_criteria_id,
+            user_id=g.account_id,
+            theme_id=theme_id,
+        )
+
+        return redirect(
+            url_for(
+                "assess_bp.display_sub_criteria",
+                application_id=application_id,
+                sub_criteria_id=sub_criteria_id,
+                theme_id=theme_id,
+                _anchor="comments",
+            )
+        )
+
+    expand_comment_box = bool(request.args.get("expand-comment-box"))
+    # used to expand the comment box when
+    # a user clicks on the add comment button, we use redirect
+    # to anchor the page to the add comment section
+    if expand_comment_box:
+        return redirect(
+            url_for(
+                "assess_bp.display_sub_criteria",
+                application_id=application_id,
+                sub_criteria_id=sub_criteria_id,
+                theme_id=theme_id,
+                add_comment=1,
+                _anchor="comment",
+            )
+        )
+
     fund = get_fund(Config.COF_FUND_ID)
-    display_comment_box = False
     is_flagged = any(get_flags(application_id))
 
     comments = get_comments(
@@ -58,6 +103,8 @@ def display_sub_criteria(
         "fund": fund,
         "comments": comments,
         "if_flagged": is_flagged,
+        "display_comment_box": add_comment_argument,
+        "comment_form": comment_form,
     }
 
     if theme_id == "score":
@@ -118,32 +165,6 @@ def display_sub_criteria(
             (2, "Partial"),
             (1, "Poor"),
         ]
-        
-        if request.args.get("add-comment") == "1":
-            display_comment_box = True
-
-        comment_form = CommentsForm()
-
-        if comment_form.validate_on_submit():
-            comment = comment_form.comment.data
-            display_comment_box = False
-            
-            submit_comment(
-                comment=comment,
-                application_id=application_id,
-                sub_criteria_id=sub_criteria_id,
-                user_id=g.account_id,
-                theme_id=theme_id,
-                )    
-            
-            return redirect(
-                url_for(
-                    "assess_bp.display_sub_criteria",
-                    application_id=application_id,
-                    sub_criteria_id=sub_criteria_id,
-                    theme_id=theme_id,
-                )
-            )
 
         return render_template(
             "sub_criteria.html",
@@ -151,8 +172,6 @@ def display_sub_criteria(
             score_list=score_list or None,
             latest_score=latest_score,
             COF_score_list=COF_score_list,
-            commentForm=comment_form,
-            displayCommentBox=display_comment_box,
             scores_submitted=scores_submitted,
             score_error=score_error,
             justification_error=justification_error,
@@ -160,47 +179,19 @@ def display_sub_criteria(
             **common_template_config,
         )
 
-    elif theme_id != "score":
-        theme_answers_response = get_sub_criteria_theme_answers(
-            application_id, theme_id
-        )
-        answers_meta = applicants_response.create_ui_components(
-            theme_answers_response, application_id
-        )
-        if request.args.get("add-comment") == "1":
-            display_comment_box = True
+    theme_answers_response = get_sub_criteria_theme_answers(
+        application_id, theme_id
+    )
+    answers_meta = applicants_response.create_ui_components(
+        theme_answers_response, application_id
+    )
 
-        comment_form = CommentsForm()
-
-        if comment_form.validate_on_submit():
-            comment = comment_form.comment.data
-            display_comment_box = False
-
-            submit_comment(
-                comment=comment,
-                application_id=application_id,
-                sub_criteria_id=sub_criteria_id,
-                user_id=g.account_id,
-                theme_id=theme_id,
-            )
-
-            return redirect(
-                url_for(
-                    "assess_bp.display_sub_criteria",
-                    application_id=application_id,
-                    sub_criteria_id=sub_criteria_id,
-                    theme_id=theme_id,
-                )
-            )
-
-        return render_template(
-            "sub_criteria.html",
-            on_summary=False,
-            answers_meta=answers_meta,
-            commentForm=comment_form,
-            displayCommentBox=display_comment_box,
-            **common_template_config,
-        )
+    return render_template(
+        "sub_criteria.html",
+        on_summary=False,
+        answers_meta=answers_meta,
+        **common_template_config,
+    )
 
 
 @assess_bp.route(

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -43,13 +43,7 @@ def display_sub_criteria(
     comment_form = CommentsForm()
 
     add_comment_argument = request.args.get("add_comment") == "1"
-    if all(
-        [
-            add_comment_argument,
-            request.method == "POST",
-            comment_form.validate_on_submit(),
-        ]
-    ):
+    if add_comment_argument and comment_form.validate_on_submit():
         comment = comment_form.comment.data
 
         submit_comment(

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -64,22 +64,6 @@ def display_sub_criteria(
             )
         )
 
-    expand_comment_box = bool(request.args.get("expand-comment-box"))
-    # used to expand the comment box when
-    # a user clicks on the add comment button, we use redirect
-    # to anchor the page to the add comment section
-    if expand_comment_box:
-        return redirect(
-            url_for(
-                "assess_bp.display_sub_criteria",
-                application_id=application_id,
-                sub_criteria_id=sub_criteria_id,
-                theme_id=theme_id,
-                add_comment=1,
-                _anchor="comment",
-            )
-        )
-
     fund = get_fund(Config.COF_FUND_ID)
     is_flagged = any(get_flags(application_id))
 

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -10,7 +10,8 @@
 {% block content %}
     <div class="govuk-phase-banner flex-parent-element">
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">{{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}</p>
-        <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right"><a href="{{ sso_logout_url }}" class="govuk-link flexed-element-margins-collapse">Log out</a></p>
+        <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right"><a
+                href="{{ sso_logout_url }}" class="govuk-link flexed-element-margins-collapse">Log out</a></p>
     </div>
 
     {% if flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
@@ -26,23 +27,27 @@
     ) }}
 
     <div class="govuk-width-container">
-        {% if not flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
-            {{ flag_application_button(application_id) }}
-        {% endif %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <div class="govuk-grid-column-two-thirds">
-                    {% for section in state.sections %}
-                        {{ section_element(section.name, section.sub_criterias, application_id) }}{% endfor %}
-                    <h2 class="govuk-heading-l govuk-!-margin-top-8">Score the application</h2>
-                    <p class="govuk-body">Assess all responses under each sub criteria.</p>
-                    {% for criteria in state.criterias %}
-                        {% set name_classes = "govuk-heading-m govuk-!-margin-bottom-2" %}
-                        {% if loop.index > 0 %}
-                            {% set name_classes = "govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8" %}
+                <div>
+                    <div class="govuk-grid-column-two-thirds">
+                        {% for section in state.sections %}
+                            {{ section_element(section.name, section.sub_criterias, application_id) }}{% endfor %}
+                        <h2 class="govuk-heading-l govuk-!-margin-top-8">Score the application</h2>
+                        <p class="govuk-body">Assess all responses under each sub criteria.</p>
+                        {% for criteria in state.criterias %}
+                            {% set name_classes = "govuk-heading-m govuk-!-margin-bottom-2" %}
+                            {% if loop.index > 0 %}
+                                {% set name_classes = "govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8" %}
+                            {% endif %}
+                            {{ criteria_element(criteria, name_classes, application_id) }}
+                        {% endfor %}
+                    </div>
+                    <div class="govuk-grid-column-one-third govuk-!-margin-top-2">
+                        {% if not flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
+                            {{ flag_application_button(application_id) }}
                         {% endif %}
-                        {{ criteria_element(criteria, name_classes, application_id) }}
-                    {% endfor %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -14,7 +14,7 @@
     </div>
     </div>
 
-    {% if flag %}
+    {% if flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
         {{ assessment_flag(flag, flag_user_info) }}
     {% endif %}
 
@@ -27,7 +27,7 @@
     ) }}
 
     <div class="govuk-width-container">
-        {% if not flag %}
+        {% if not flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
             {{ flag_application_button(application_id) }}
         {% endif %}
         <div class="govuk-grid-row">

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -45,7 +45,7 @@
                                     'classes': 'govuk-label govuk-label--s'
                                 },
                                 'errorMessage': {
-                                    'text': 'Please provide a reason for flagging this application'
+                                    'text': form.errors.get("reason") | join("\n")
                                 } if form.errors.get("reason") else None,
                                 'rows': 8,
                                 'value': form.reason.data or ""
@@ -59,7 +59,7 @@
                                     'classes': 'govuk-label govuk-label--s'
                                 },
                                 'errorMessage': {
-                                    'text': 'Please provide which section you are flagging'
+                                    'text': form.errors.get("section") | join("\n"),
                                 } if form.errors.get("section") else None,
                                 'value': form.section.data or ""
                             }) }}

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
+{%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {% from "macros/banner_summary.html" import banner_summary %}
 
 {% block content %}
@@ -36,42 +37,32 @@
                                 to either resolve your query, or stop the assessment.
                             </p>
 
-                            {% if form.errors.get("reason") %}
-                                <p class="govuk-error-message">
-                                    <span class="govuk-visually-hidden">Error:</span> Please provide a reason for
-                                    flagging this application
-                                </p>
-                            {% endif %}
+                            {{ govukTextarea({
+                                'id': form.reason.id,
+                                'name': form.reason.id,
+                                'label': {
+                                    'text': 'Reason for flagging',
+                                    'classes': 'govuk-label govuk-label--s'
+                                },
+                                'errorMessage': {
+                                    'text': 'Please provide a reason for flagging this application'
+                                } if form.errors.get("reason") else None,
+                                'rows': 8,
+                                'value': form.reason.data or ""
+                            }) }}
 
-                            <div class="govuk-form-group">
-                                <label class="govuk-label govuk-label--s" for="reason">
-                                    Reason for flagging
-                                </label>
-                                <textarea class="govuk-textarea"
-                                          id="reason"
-                                          name="reason"
-                                          rows="8">{{ form.reason.data or "" }}</textarea>
-                            </div>
-
-                            {% if form.errors.get("section") %}
-                                <p class="govuk-error-message">
-                                    <span class="govuk-visually-hidden">Error:</span> Please provide which section you
-                                    are flagging
-                                </p>
-                            {% endif %}
-
-                            <div class="govuk-form-group">
-                                <label class="govuk-label govuk-label--s"
-                                       for="section">
-                                    Section to flag
-                                </label>
-                                <input class="govuk-input"
-                                       id="section"
-                                       name="section"
-                                       type="text"
-                                       value="{{ form.section.data or "" }}">
-                            </div>
-
+                            {{ govukTextarea({
+                                'id': form.section.id,
+                                'name': form.section.id,
+                                'label': {
+                                    'text': 'Section to flag',
+                                    'classes': 'govuk-label govuk-label--s'
+                                },
+                                'errorMessage': {
+                                    'text': 'Please provide which section you are flagging'
+                                } if form.errors.get("section") else None,
+                                'value': form.section.data or ""
+                            }) }}
 
                             <div class="govuk-button-group">
                                 <button class="govuk-button primary-button"

--- a/app/assess/templates/macros/comments.html
+++ b/app/assess/templates/macros/comments.html
@@ -1,5 +1,5 @@
 {% macro comment(comments) %}
-<div class="govuk-!-margin-top-7" id="anchor">
+<div class="govuk-!-margin-top-7" id="comments">
     <h2 class="govuk-heading-m">Comments</h2>
     <div id="more-detail-hint" class="govuk-hint">
       <p class="govuk-hint">Summarise any thoughts you have on the information provided.</p>

--- a/app/assess/templates/macros/comments_box.html
+++ b/app/assess/templates/macros/comments_box.html
@@ -1,15 +1,15 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro commentBox(commentForm) %}
+{% macro comment_box(comment_form) %}
 
 <form method="POST">
 <div class="govuk-grid-row">
-    {{ commentForm.csrf_token }}
+    {{ comment_form.csrf_token }}
     <div class="govuk-grid-column-three-quarters">
     {{ govukTextarea({
-    "name": commentForm.comment.id,
-    "id": commentForm.comment.id,
+    "name": comment_form.comment.id,
+    "id": comment_form.comment.id,
     "label": {
       "text": "Add a comment",
       "classes": "govuk-label--s",

--- a/app/assess/templates/macros/comments_summary.html
+++ b/app/assess/templates/macros/comments_summary.html
@@ -1,5 +1,5 @@
 {% macro comment_summary(comments, themes) %}
-<div class="govuk-!-margin-top-7" id="anchor">
+<div class="govuk-!-margin-top-7" id="comments">
     <h2 class="govuk-heading-m">Comments</h2>
     <div id="more-detail-hint" class="govuk-hint">
       <p class="govuk-hint">Summarise any thoughts you have on the information provided.</p>

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -52,21 +52,24 @@
                 {{comment(comments)}}
                 {% endif %}
                 {% if display_comment_box != True %}
-                    <form method="GET">
-                        <button
-                            id="comment"
-                            class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
-                            type="submit"
-                            data-module="govuk-button"
-                            value="add-comment"
-                        >
-                            {% if comments == None %} Add a comment
-                            {% else %} Add another comment
-                            {% endif %}
-                        </button>
-                        <input type="hidden" name="theme_id" value="{{current_theme_id}}">
-                        <input type="hidden" name="expand-comment-box" value="1">
-                    </form>
+                    <a
+                        id="comment"
+                        class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
+                        type="submit"
+                        data-module="govuk-button"
+                        href="{{ url_for(
+                            "assess_bp.display_sub_criteria",
+                            application_id=application_id,
+                            sub_criteria_id=sub_criteria.id,
+                            theme_id=current_theme_id,
+                            add_comment="1",
+                            _anchor="comment"
+                        ) }}"
+                    >
+                        {% if comments == None %} Add a comment
+                        {% else %} Add another comment
+                        {% endif %}
+                    </a>
                     {% endif %}
 
                     {% if display_comment_box == True %}

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -53,7 +53,13 @@
                 {% endif %}
                 {% if display_comment_box != True %}
                     <form method="GET">
-                        <button id="comment" class="govuk-button secondary-button govuk-!-margin-top-2" type="submit" data-module="govuk-button" value="add-comment">
+                        <button
+                            id="comment"
+                            class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
+                            type="submit"
+                            data-module="govuk-button"
+                            value="add-comment"
+                        >
                             {% if comments == None %} Add a comment
                             {% else %} Add another comment
                             {% endif %}

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -26,7 +26,7 @@
     ) }}
 
     <div class="govuk-width-container">
-        {% if not is_flagged %}
+        {% if not is_flagged and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
             {{ flag_application_button(application_id) }}
         {% endif %}
         <div class="govuk-grid-row">

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -7,7 +7,7 @@
 {% from "macros/flag_application_button.html" import flag_application_button %}
 {% from "macros/comments.html" import comment %}
 {% from "macros/comments_summary.html" import comment_summary %}
-{% from "macros/comments_box.html" import commentBox %}
+{% from "macros/comments_box.html" import comment_box %}
 
 
 {% block content %}
@@ -51,20 +51,20 @@
                 {% else %}
                 {{comment(comments)}}
                 {% endif %}
-                {% if displayCommentBox != True %}
+                {% if display_comment_box != True %}
                     <form method="GET">
-                        <button id="comment-button-community" class="govuk-button secondary-button govuk-!-margin-top-2" type="submit" data-module="govuk-button" value="add-comment">
+                        <button id="comment" class="govuk-button secondary-button govuk-!-margin-top-2" type="submit" data-module="govuk-button" value="add-comment">
                             {% if comments == None %} Add a comment
                             {% else %} Add another comment
                             {% endif %}
                         </button>
                         <input type="hidden" name="theme_id" value="{{current_theme_id}}">
-                        <input type="hidden" name="add-comment" value="1">
+                        <input type="hidden" name="expand-comment-box" value="1">
                     </form>
                     {% endif %}
 
-                    {% if displayCommentBox == True %}
-                        {{ commentBox(commentForm) }}
+                    {% if display_comment_box == True %}
+                        {{ comment_box(comment_form) }}
                     {% endif %}
             </div>
         </div>

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -229,11 +229,11 @@ class TestJinjaMacros(object):
 
     def test_comment_macro(self, request_ctx):
         rendered_html = render_template_string(
-            "{{commentBox(commentForm)}}",
-            commentBox=get_template_attribute(
-                "macros/comments_box.html", "commentBox"
+            "{{comment_box(comment_form)}}",
+            comment_box=get_template_attribute(
+                "macros/comments_box.html", "comment_box"
             ),
-            commentForm=CommentsForm(),
+            comment_form=CommentsForm(),
         )
 
         # replacing new lines to more easily regex match the html


### PR DESCRIPTION
Pull request includes changes for multiple things:

- Anchors for comments
    - I've refactored and taken the duplicate comment creation logic and put it at the top
    - We handle scenarios for initially expanding a comment, and submitting it
    - Having this at the top means we can return redirects when required, otherwise continue the flow without indentation

- Role checks for displaying Flags and "Flag application" button 
    - Now, only Assessor's and Lead Assessors can create & view flags
    - Also refactored the form to use govukTextarea rather than out own logic

Edit:  Have since pushed https://github.com/communitiesuk/funding-service-design-assessment/pull/107/commits/dc89424e10bc082bbaf52ceecd2c08bbe9f439ef to include some styling/qol changes, i.e. using proper error messages instead of hard-coding in the html template

