### PR TITLE
FS-2129-update-comments-summary-section-with-theme-names-and-no-comment-message

### DIFF
--- a/app/assess/templates/macros/comments_summary.html
+++ b/app/assess/templates/macros/comments_summary.html
@@ -1,34 +1,35 @@
 {% macro comment_summary(comments, themes) %}
 <div class="govuk-!-margin-top-7" id="anchor">
-    <h2 class="govuk-heading-m">Comments</h2>
-    <div id="more-detail-hint" class="govuk-hint">
-      <p class="govuk-hint">Summarise any thoughts you have on the information provided.</p>
-      <p class="govuk-hint">You cannot edit or delete your comment once you have saved it.</p>
-    </div>
-    {% if not comments %}
-    <div class="govuk-body govuk-!-margin-top-6">
-        No comments have been left yet.
-        </div>
-    {% else %}
+    <h2 class="govuk-heading-l">Comments</h2>
+
     {% for theme in themes %}
+       <h3 class="govuk-heading-m">{{theme.name}}</h3>
+
     {% if comments[theme.id]|length > 0%}
-    <h3 class="govuk-heading-m">{{theme.name}}</h3>
-        {% for comment in comments[theme.id] %}
-            {% if g.user.highest_role == "COMMENTER" and (comment.highest_role == "ASSESSOR" or comment.highest_role == "LEAD_ASSESSOR") %}
-                <div class="comment-group">
-                    <p class="govuk-body">Permission required to see comment.</p>
-                </div>
-            {% else %}
-                <div class="comment-group">
-                    <p class="govuk-body">{{comment.comment}}</p>
-                    <p class="govuk-body-s">{{comment.full_name}} ({{comment.highest_role|all_caps_to_human}}) {{comment.email_address}}</p>
-                    <p class="govuk-body-s">{{comment.date_created|datetime_format_24hr}}</p>
-                </div>
-            {% endif %}
+
+    {% for comment in comments[theme.id] %}
+    {% if g.user.highest_role == "COMMENTER" and (comment.highest_role == "ASSESSOR" or comment.highest_role ==
+    "LEAD_ASSESSOR") %}
+        <div class="comment-group">
+            <p class="govuk-body">Permission required to see comment.</p>
+        </div>
+        {% else %}
+        <div class="comment-group">
+            <p class="govuk-body">{{comment.comment}}</p>
+            <p class="govuk-body-s">{{comment.full_name}} ({{comment.highest_role|all_caps_to_human}})
+                {{comment.email_address}}</p>
+            <p class="govuk-body-s">{{comment.date_created|datetime_format_24hr}}</p>
+        </div>
+        {% endif %}
         {% endfor %}
-            </br>
-     {%endif%}
+        </br>
+
+    {% else %}
+        <div class="govuk-body govuk-!-margin-top-3">
+            There are currently no comments for this section.
+        </div>
+    {%endif%}
     {% endfor %}
-    {% endif %}
+
 </div>
 {% endmacro %}


### PR DESCRIPTION
Updated contents as per the prototype for scoring page for comments summary section