### PR TITLE
FS-2136: Set sub criteria width to one half

### DIFF
--- a/app/assess/templates/macros/criteria_element.html
+++ b/app/assess/templates/macros/criteria_element.html
@@ -35,7 +35,7 @@
         govukTable({
         "firstCellIsHeader":false,
         "head": [
-            { "text": "Assessment sub criteria" },
+            { "text": "Assessment sub criteria", "classes": "govuk-!-width-one-half"  },
             { "text": "Score out of 5", "format": "numeric" } if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] else None,
             { "text": "Status", "format": "numeric" }
         ],


### PR DESCRIPTION
- Set sub criteria width to one half, should enable consistency even with long names

**Before:**

![image](https://user-images.githubusercontent.com/117724519/211536248-82821753-6d54-4273-8190-dbce26b8ed5e.png)

**After:**

![image](https://user-images.githubusercontent.com/117724519/211536291-1a2d4ac3-0634-4eff-89b4-14b51e1709a2.png)
