### PR TITLE
FS-2145 Comments link fix

### DIFF
--- a/app/assess/templates/macros/comments_summary.html
+++ b/app/assess/templates/macros/comments_summary.html
@@ -1,6 +1,6 @@
 {% macro comment_summary(comments, themes) %}
 
-<div class="govuk-!-margin-top-7" id="anchor">
+<div class="govuk-!-margin-top-7" id="comments">
     <h2 class="govuk-heading-l">Comments</h2>
 
     {% for theme in themes %}

--- a/app/assess/templates/macros/scores_justification.html
+++ b/app/assess/templates/macros/scores_justification.html
@@ -56,7 +56,7 @@
             <h2 class="govuk-heading-m">Score</h2>
             {% endif %}
             <p class="govuk-body">Based on the <a class="govuk-link govuk-link--no-visited-state"
-                    href="#comments-heading">comments</a>, score this sub criteria against
+                    href="#comments">comments</a>, score this sub criteria against
                 the&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="https://mhclg.sharepoint.com/:w:/s/CommunityOwnershipFund/Ecv3iM7U0AtKtyHnzRrQ9dsB0HdMPvHWqAoGn1WrWM7EMA?e=6QpdUT">assessment
                     criteria</a>.</p>
             <p class="govuk-body">You can rescore at any point.</p>


### PR DESCRIPTION
The comments link on the scoring page will now take the user to the comment section