### PR TITLE
BAU: Only call progress endpoint if we have data

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -233,12 +233,11 @@ def landing():
     assessment_deadline = get_round(
         Config.COF_FUND_ID, Config.COF_ROUND2_ID
     ).assessment_deadline
-    
+
     # Updating assessment progress for applications
-    application_overviews = get_assessment_progress(
-        application_overviews
-        )
-  
+    if application_overviews:
+        application_overviews = get_assessment_progress(application_overviews)
+
     return render_template(
         "assessor_dashboard.html",
         user=g.user,
@@ -344,6 +343,8 @@ def sub_crit_scoring():
 
 @assess_bp.route("/file/<application_id>/<file_name>", methods=["GET"])
 def get_file(application_id: str, file_name: str):
-    response = get_file_response(application_id=application_id, file_name=file_name)
-    
+    response = get_file_response(
+        application_id=application_id, file_name=file_name
+    )
+
     return response

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -234,14 +234,16 @@ def landing():
         Config.COF_FUND_ID, Config.COF_ROUND2_ID
     ).assessment_deadline
 
-    # Updating assessment progress for applications
-    if application_overviews:
-        application_overviews = get_assessment_progress(application_overviews)
+    post_processed_overviews = (
+        get_assessment_progress(application_overviews)
+        if application_overviews
+        else []
+    )
 
     return render_template(
         "assessor_dashboard.html",
         user=g.user,
-        application_overviews=application_overviews,
+        application_overviews=post_processed_overviews,
         assessment_deadline=assessment_deadline,
         query_params=search_params,
         asset_types=asset_types,


### PR DESCRIPTION
- Only call the progress endpoint if we actually have data, if we don't, no point in calling it

Fixes: 
- https://communities-govuk.slack.com/archives/C02PHBER287/p1673449332218439
- https://sentry.io/organizations/funding-service-design-team-dl/issues/3850987122/?referrer=slack