### PR TITLE
BAU: add account store to dev/test manifests

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -17,6 +17,7 @@ applications:
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://cae245fff7d8483e9d73c73b30137ffc@o1432034.ingest.sentry.io/4504418515550208
+    ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-dev.london.cloudapps.digital
     GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http
@@ -39,6 +40,7 @@ applications:
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://cae245fff7d8483e9d73c73b30137ffc@o1432034.ingest.sentry.io/4504418515550208
+    ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-test.london.cloudapps.digital
     GITHUB_SHA: ((GITHUB_SHA))
   services:
     - form-uploads-test


### PR DESCRIPTION
Add missing config to manifests, should fix Sentry errors e.g.
![Screenshot 2023-01-12 at 11 43 02](https://user-images.githubusercontent.com/1764158/212058113-0fa166e7-8c4b-40df-a243-2513d953cdb4.png)
