### PR TITLE
FS-2160: Text area now matches prototype

### DIFF
--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -51,6 +51,7 @@
                             {{ govukTextarea({
                                 'id': form.section.id,
                                 'name': form.section.id,
+                                'rows': '1',
                                 'label': {
                                     'text': 'Section to flag',
                                     'classes': 'govuk-label govuk-label--s'


### PR DESCRIPTION
Text area for section to flag now macthes prototype
![image](https://user-images.githubusercontent.com/97108643/212084977-38dad5fe-55e3-496e-9ded-0600dc29cc65.png)