### PR TITLE
Fs 2008 stopped banner

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -368,7 +368,7 @@ def get_latest_flag(application_id: str) -> list[Flag] | None:
         )
     )
     if flag:
-        return Flag.from_dict(flag)
+        return Flag.from_dict(flag[0])
     else:
         msg = f"flag for application: '{application_id}' not found."
         current_app.logger.warn(msg)

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -368,7 +368,7 @@ def get_latest_flag(application_id: str) -> list[Flag] | None:
         )
     )
     if flag:
-        return Flag.from_dict(flag[0])
+        return Flag.from_dict(flag)
     else:
         msg = f"flag for application: '{application_id}' not found."
         current_app.logger.warn(msg)

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -241,6 +241,7 @@ def landing():
         Config.COF_FUND_ID, Config.COF_ROUND2_ID
     ).assessment_deadline
 
+
     stats = get_assessments_stats(Config.COF_FUND_ID, Config.COF_ROUND2_ID)
 
     post_processed_overviews = (

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -25,7 +25,8 @@
         state.short_id,
         state.project_name,
         state.funding_amount_requested,
-        state.workflow_status
+        state.workflow_status,
+        flag
     ) }}
 
     <div class="govuk-width-container">

--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -1,7 +1,12 @@
 {% macro assessment_flag(flag, user_info, application_id) %}
     <div class="assessment-alert assessment-alert--flagged">
-        <h1 class="assessment-alert__heading govuk-heading-l">{{ flag.flag_type.name | title }}</h1>
-
+        <h1 class="assessment-alert__heading govuk-heading-l">
+            {% if flag.flag_type.name == "STOPPED" %}
+                Assessment Stopped
+            {% else %}
+                {{ flag.flag_type.name | title }}
+            {% endif %}
+        </h1>
         <h2 class="govuk-heading-m">Reason</h2>
         <p class="govuk-body">{{ flag.justification }}</p>
         <h2 class="govuk-heading-m">Section flagged</h2>

--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -1,4 +1,4 @@
-{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, workflow_status) %}
+{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, workflow_status, flag) %}
 
 </div> {# This div is here on purpose. #}
 <div class="fsd-banner-background">
@@ -13,7 +13,13 @@
                         name: {{ project_name }}</h3>
                     <h3 class="govuk-body-l fsd-banner-content">Total funding requested:
                         &pound;{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
-                    <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">{{ workflow_status | status_to_human }}</h3>
+                    <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
+                        {% if flag %}
+                            {{ flag.flag_type.name | capitalize }}
+                        {% else %}
+                            {{ workflow_status | status_to_human }}
+                        {% endif %}
+                    </h3>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Banner for STOPPED Assessment Completed

- Assessment Stopped Header displayed in place of "Flagged" when an application has a "STOPPED" flag
- The banner summary also now has "Stopped" in place of the workflow_status if the flag is present
- Tests have been written to check if the UI is showing accurate to Flagged/Assessment Stopped heading
- Banner_summary now has a default parameter of flag=None, and the banner only adjust to the stopped flag is this flag is not None