### PR TITLE
BAU: fix score label

### DIFF
--- a/app/assess/templates/macros/scores.html
+++ b/app/assess/templates/macros/scores.html
@@ -12,9 +12,9 @@
         <div class="govuk-radios" data-module="govuk-radios">
             {% for score, description in score_list %}
             <div class="govuk-radios__item">
-                <input class="govuk-radios__input" aria-label="Scoring" id={{"score-{}".format(score)}} name={{score_form_name}}
+                <input class="govuk-radios__input" id={{"score-{}".format(score)}} name={{score_form_name}}
                     type="radio" value={{score}}>
-                <label class="govuk-label govuk-radios__label" for={{score_form_name}}>
+                <label class="govuk-label govuk-radios__label" for={{"score-{}".format(score)}}>
                     <span class="govuk-!-font-weight-bold">{{score}}</span> {{description}}
                 </label>
             </div>


### PR DESCRIPTION
Label for attribute needs to match input ID to be usable. This meant text label isn't clickable and wouldn't have been associated by screenreaders. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label for context on HTML.

## Before
https://user-images.githubusercontent.com/1764158/213491551-99365b25-21a0-4a2f-8b60-814372efc600.mov

## After
https://user-images.githubusercontent.com/1764158/213491609-655bcad4-38d6-4441-8d26-b0242ea48528.mov

