### PR TITLE
FS-2177-save-score-rationale-without-scores

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -143,8 +143,8 @@ def display_sub_criteria(
             current_app.logger.info(f"Processing POST to {request.path}.")
             if form.validate_on_submit():
                 score = int(form.score.data)
-                justification = form.justification.data
                 user_id = g.account_id
+                justification = form.justification.data
                 submit_score_and_justification(
                     score=score,
                     justification=justification,
@@ -158,7 +158,7 @@ def display_sub_criteria(
                 score_error = True if not form.score.data else False
                 justification_error = (
                     True if not form.justification.data else False
-                )
+                )      
         # call to assessment store to get latest score
         score_list = get_score_and_justification(
             application_id, sub_criteria_id, score_history=True

--- a/app/assess/templates/macros/justification.html
+++ b/app/assess/templates/macros/justification.html
@@ -1,6 +1,6 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 
-{% macro justification(justification_form_name, justification_error) %}
+{% macro justification(form, justification_error) %}
 
 <div class="govuk-form-group comments {% if justification_error %}govuk-form-group--error{% endif %}" name="just-text-area" id="just-text-area">
     <h2 class="govuk-label-wrapper">
@@ -16,8 +16,10 @@
         <span class="govuk-visually-hidden">Error:</span> Please provide rationale for this score
       </p>
     {% endif %}
-    <textarea class="govuk-textarea" id="justification" name={{justification_form_name}} value=""
-        rows="10" aria-describedby="more-detail-hint"></textarea>
+    <textarea class="govuk-textarea" id="justification" name={{form.justification.id}}
+        rows="10" aria-describedby="more-detail-hint">
+        {% if form.justification.data %}{{form.justification.data}}{% endif %}
+    </textarea>
 </div>
 
 {% endmacro %}

--- a/app/assess/templates/macros/scores_justification.html
+++ b/app/assess/templates/macros/scores_justification.html
@@ -67,7 +67,7 @@
                     criteria</a>.</p>
             <p class="govuk-body">You can rescore at any point.</p>
             {{scores(form.score.id, COF_score_list, score_error)}}
-            {{justification(form.justification.id, justification_error)}}
+            {{justification(form, justification_error)}}
         </div>
         {% if latest_score %}
             {{govukButton({'text': 'Save a new score', 'type':'submit', 'classes': 'primary-button'})}}

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from app.assess.forms.comments_form import CommentsForm
+from app.assess.forms.scores_and_justifications import ScoreForm
 from app.assess.models.ui.applicants_response import AboveQuestionAnswerPair
 from app.assess.models.ui.applicants_response import (
     AboveQuestionAnswerPairHref,
@@ -249,11 +250,11 @@ class TestJinjaMacros(object):
 
     def test_justification_macro(self, request_ctx):
         rendered_html = render_template_string(
-            "{{justification(justification_form_name, justification_error)}}",
+            "{{justification(form, justification_error)}}",
             justification=get_template_attribute(
                 "macros/justification.html", "justification"
             ),
-            justification_form_name="Justification",
+            form=ScoreForm(),
             justification_error=True,
         )
 


### PR DESCRIPTION
The "justification" macro is designed to save any rationale provided by the user, even if the assessment has not been scored yet. This means that if the user enters text into the text area for the rationale, but does not provide a score for the assessment, the page will still save the rationale text entered by the user.