### PR TITLE
Fix determine display status

### DIFF
--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -9,12 +9,14 @@ from flask import request
 from flask import url_for
 
 
-def determine_display_status(state, latest_flag):
+def determine_display_status(state, latest_flag=None):
     """
     Deduce whether to override display_status with a
     flag.
     """
-    if latest_flag.flag_type == FlagType.RESOLVED:
+    if not latest_flag:
+        state.display_status = state.workflow_status
+    elif latest_flag and latest_flag.flag_type == FlagType.RESOLVED:
         state.display_status = state.workflow_status
         state.flag_resolved = True
     else:

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -76,8 +76,7 @@ def display_sub_criteria(
     fund = get_fund(Config.COF_FUND_ID)
 
     flag = get_latest_flag(application_id)
-    if flag:
-        determine_display_status(sub_criteria, flag)
+    determine_display_status(sub_criteria, flag)
 
     comments = get_comments(
         application_id=application_id,
@@ -133,7 +132,7 @@ def display_sub_criteria(
                 score_error = True if not form.score.data else False
                 justification_error = (
                     True if not form.justification.data else False
-                )      
+                )
         # call to assessment store to get latest score
         score_list = get_score_and_justification(
             application_id, sub_criteria_id, score_history=True
@@ -301,8 +300,8 @@ def application(application_id):
     )
     flag = get_latest_flag(application_id)
     if flag:
-        determine_display_status(state, flag)
         accounts = get_bulk_accounts_dict([flag.user_id])
+    determine_display_status(state, flag)
 
     sub_criteria_status_completed = all_status_completed(state)
     form = AssessmentCompleteForm()

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -17,6 +17,12 @@
         {{ logout_partial(sso_logout_url) }}
     </div>
 
+    {% if flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "FLAGGED" %}
+        {{ assessment_flagged(flag, flag_user_info, application_id, current_user_role) }}
+    {% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "STOPPED" %}
+        {{ assessment_stopped(flag, flag_user_info, application_id, current_user_role) }}
+    {% endif %}
+
     {% if state.workflow_status=="COMPLETED" %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -30,12 +36,7 @@
                 </p>
             </div>
         </div>
-    {% endif %}
-
-    {% if flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "FLAGGED" %}
-        {{ assessment_flagged(flag, flag_user_info, application_id, current_user_role) }}
-    {% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "STOPPED" %}
-        {{ assessment_stopped(flag, flag_user_info, application_id, current_user_role) }}
+    </div>
     {% elif sub_criteria_status_completed %}
     <form method="POST" action="{{ url_for('assess_bp.application', application_id=application_id) }}">
         {{ form.csrf_token }}

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -10,27 +10,29 @@
 {% from "macros/logout_partial.html" import logout_partial %}
 
 {% block content %}
-<div class="govuk-phase-banner flex-parent-element">
-    <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
-        {{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}
-    </p>
-    {{ logout_partial(sso_logout_url) }}
-</div>
-
-{% if state.workflow_status=="COMPLETED" %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <div class="assessment-complete  govuk-margin-bottom-8">
-            <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">
-                Assessment complete</h2>
-            <p class="govuk-body">You have marked this assessment as complete.</p>
-            <p class="govuk-body">
-                It may now be selected for quality assurance (QA). New scores and rationales could be added if this
-                happens.
-            </p>
-        </div>
+    <div class="govuk-phase-banner flex-parent-element">
+        <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
+            {{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}
+        </p>
+        {{ logout_partial(sso_logout_url) }}
     </div>
-    {% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "FLAGGED" %}
+
+    {% if state.workflow_status=="COMPLETED" %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="assessment-complete  govuk-margin-bottom-8">
+                <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">
+                    Assessment complete</h2>
+                <p class="govuk-body">You have marked this assessment as complete.</p>
+                <p class="govuk-body">
+                    It may now be selected for quality assurance (QA). New scores and rationales could be added if this
+                    happens.
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "FLAGGED" %}
         {{ assessment_flagged(flag, flag_user_info, application_id, current_user_role) }}
     {% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and state.display_status == "STOPPED" %}
         {{ assessment_stopped(flag, flag_user_info, application_id, current_user_role) }}


### PR DESCRIPTION
Always call determine display status so that templates have a value to render for display_status.
Allow flagging workflow on completed applications.