### PR TITLE
FS-2228-save-radio-button-selection-on-flag-resolve-without-filling-reason

### DIFF
--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -24,8 +24,7 @@ def determine_display_status(state, latest_flag=None):
 
 
 def resolve_application(
-    form, application_id, flag, justification, section, page_to_render,
-    resolution_flag=None
+    form, application_id, flag, justification, section, page_to_render
 ):
     """ This function is used to resolve an application by submitting a flag, justification, and section for the application.
 
@@ -36,8 +35,7 @@ def resolve_application(
         justification (str): Justification for the flag submitted
         section (str): Section of the application the flag is submitted for
         page_to_render (str): Template name to be rendered
-        resolution_flag (str, optional): Additional flag for the resolution process, used to preselect a radio field option. Defaults to None
-
+        
     Returns:
         redirect: Redirects to the application page if the request method is "POST" and form is valid.
         render_template: Renders the specified template with the application_id, fund_name, state, form, and referrer as parameters.

--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -24,8 +24,24 @@ def determine_display_status(state, latest_flag=None):
 
 
 def resolve_application(
-    form, application_id, flag, justification, section, page_to_render
+    form, application_id, flag, justification, section, page_to_render,
+    resolution_flag=None
 ):
+    """ This function is used to resolve an application by submitting a flag, justification, and section for the application.
+
+    Args:
+        form (obj): Form object to be validated and submitted
+        application_id (int): ID of the application
+        flag (str): Flag submitted for the application
+        justification (str): Justification for the flag submitted
+        section (str): Section of the application the flag is submitted for
+        page_to_render (str): Template name to be rendered
+        resolution_flag (str, optional): Additional flag for the resolution process, used to preselect a radio field option. Defaults to None
+
+    Returns:
+        redirect: Redirects to the application page if the request method is "POST" and form is valid.
+        render_template: Renders the specified template with the application_id, fund_name, state, form, and referrer as parameters.
+    """
     if request.method == "POST" and form.validate_on_submit():
         submit_flag(application_id, flag, justification, section)
         return redirect(

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -426,7 +426,6 @@ def resolve_flag(application_id):
         justification=form.justification.data,
         section=section,
         page_to_render="resolve_flag.html",
-        resolution_flag=form.resolution_flag.data,
     )
 
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -426,6 +426,7 @@ def resolve_flag(application_id):
         justification=form.justification.data,
         section=section,
         page_to_render="resolve_flag.html",
+        resolution_flag=form.resolution_flag.data,
     )
 
 

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -46,6 +46,7 @@ flag
           "text": "resolve",
           "for": form.resolution_flag.id
           },
+          "checked": form.resolution_flag.data=="RESOLVED"
           },
           {
           "value": "STOPPED",
@@ -54,6 +55,7 @@ flag
           "text": "resolve",
           "for": form.resolution_flag.id
           },
+          "checked": form.resolution_flag.data=="STOPPED"
           }
           ],
           "errorMessage": {

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -6,6 +6,7 @@
 {% from "macros/logout_partial.html" import logout_partial %}
 
 {% block content %}
+{{form.resolution_flag.data}}
 <div class="govuk-phase-banner flex-parent-element">
   <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
     {{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -6,7 +6,6 @@
 {% from "macros/logout_partial.html" import logout_partial %}
 
 {% block content %}
-{{form.resolution_flag.data}}
 <div class="govuk-phase-banner flex-parent-element">
   <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
     {{ govukBackLink({'href': url_for("assess_bp.landing"), 'text': 'Back to assessment dashboard'}) }}


### PR DESCRIPTION
Saves the radio field option data when clicked  and preselect the radio filed option when page is reloaded