### PR TITLE
FS-2247-progress-percentage-removed-if-status-assessment-complete

### DIFF
--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -124,6 +124,10 @@
                 <span class="not-started-tag">
                   {{assessment_statuses[overview.workflow_status]}}
                 </span>
+                {% elif overview.workflow_status == "COMPLETED" %}
+                <span>
+                  {{assessment_statuses[overview.workflow_status]}}
+                </span>
                 {% else %}
                 <span>
                   {{assessment_statuses[overview.workflow_status]}}

--- a/app/assess/templates/question.html
+++ b/app/assess/templates/question.html
@@ -4,7 +4,7 @@
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 
 {% block beforeContent %}
-<a href="{{url_for('assess_bp.application', application_id=application.identifier)}}" class="govuk-back-link">
+<a href="{{url_for('assess_bp.application', application_id=application.identifier)}}" class="govuk-back-link" id="back-to-link">
   Back to <b>{{application.identifier}}</b></a>
 {% endblock %}
 


### PR DESCRIPTION
A condition has been re-implemented, which states that the progress percentage of an assessment will only be visible when the status is "In progress" and will not be displayed when the status is "Assessment complete." This means that once the assessment is completed, the percentage of completion will no longer be shown.