### PR TITLE
FS-2268-hide-dashboard-status-for-commenters

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -10,6 +10,7 @@
         {{ logout_partial(sso_logout_url) }}
     </div>
     </div>
+
     <div class="fsd-banner-background">
         <div class="govuk-width-container">
             <div class="govuk-grid-row">
@@ -37,6 +38,6 @@
         </div>
     </div>
     <div class="govuk-width-container">
-      {{ application_overviews_table.render(application_overviews, query_params, asset_types, assessment_statuses, show_clear_filters) }}
+      {{ application_overviews_table.render(application_overviews, query_params, asset_types, assessment_statuses, show_clear_filters, user.highest_role) }}
  </div>
 {% endblock %}

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -69,7 +69,7 @@
         state.short_id,
         state.project_name,
         state.funding_amount_requested,
-        state.display_status,
+        state.display_status if g.user.highest_role != "COMMENTER" else " ",
         flag
     ) }}
 

--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -1,7 +1,7 @@
 {% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
 
 
-{% macro render(application_overviews, query_params, asset_types, assessment_statuses, show_clear_filters) -%}
+{% macro render(application_overviews, query_params, asset_types, assessment_statuses, show_clear_filters, user_role) -%}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full search-bar-flex-container">
     <div>
@@ -89,9 +89,11 @@
         Location
       </th>
 
+      {% if user_role != "COMMENTER" %}
       <th scope="col" class="govuk-table__header">
         Status
       </th>
+      {% endif %}
 
     </tr>
   </thead>
@@ -105,6 +107,8 @@
                 <td class="govuk-table__cell">{{asset_types[overview.asset_type]}}</td>
                 <td class="govuk-table__cell">&pound;{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
                 <td class="govuk-table__cell">{{ overview.location_json_blob.country}}</td>
+
+                {% if user_role != "COMMENTER" %}
                 <td class="govuk-table__cell">
                 {% if overview.is_qa_complete and not overview.flags[-1].flag_type in ("FLAGGED", "STOPPED") %}
                 <span class="">QA complete</span>
@@ -135,6 +139,7 @@
                 </span>
                 {% endif %}
                 </td>
+                {% endif %}
             </tr>
         {% endfor %}
   </tbody>

--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -23,10 +23,12 @@
                   {% for item in asset_types %}
                         <option value='{{ item }}' {% if query_params.asset_type == item %} selected=""{%endif%}>{{asset_types[item]}}</option>
                   {% endfor %}
-
             </select>
+            {% if user_role == "COMMENTER" %}
+            <button class="govuk-button search-button" aria-label="Search" type="submit">Search</button>
+            {% endif %}
       </div>
-
+      {% if user_role != "COMMENTER" %}
       <div class="govuk-form-group govuk-!-display-inline-block govuk-!-padding-right-2">
             <label class="govuk-label" for="filter_status">
             Filter by status
@@ -38,6 +40,7 @@
             </select>
             <button class="govuk-button search-button" aria-label="Search" type="submit">Search</button>
       </div>
+      {% endif %}
   </form>
   </div>
   {% if show_clear_filters == true %}


### PR DESCRIPTION
Functionality added to hide the status of application assessment for commenters because  the commenters should not have the visibility to see the status column in the assessment dashboard and on the assessment overview banner. 

Assessor Dashboard:

<img width="1748" alt="Screenshot 2023-02-03 at 16 37 45" src="https://user-images.githubusercontent.com/80714392/216657803-db66c110-09bb-4d3c-9b76-9814a0fde07c.png">

Assessment overview:

<img width="1782" alt="Screenshot 2023-02-03 at 16 37 55" src="https://user-images.githubusercontent.com/80714392/216657857-8fe50a86-bd4b-4464-91f8-1cdedf23948b.png">

