### PR TITLE
FS-2287: Set unique title tags for pages

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -4,7 +4,7 @@
 {% import 'components/application_overviews_table.html' as application_overviews_table-%}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/logout_partial.html" import logout_partial %}
-
+{% set pageHeading %}Team dashboard{% endset %}
 {% block content %}
     <div class="govuk-phase-banner flex-parent-element">
         {{ logout_partial(sso_logout_url) }}
@@ -15,7 +15,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <div class="govuk-grid-column-two-thirds">
-                        <h1 class="govuk-heading-xl fsd-banner-content">Team dashboard</h1>
+                        <h1 class="govuk-heading-xl fsd-banner-content">{{pageHeading}}</h1>
                         {% if user.highest_role == "LEAD_ASSESSOR" %}
                             <div class="govuk-body fsd-banner-content lead-dashboard-stats">
                                 <div class="lead-dashboard-stat">

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -11,7 +11,7 @@
 {% from "macros/logout_partial.html" import logout_partial %}
 {% from "macros/qa_complete_flag.html" import qa_complete_flag %}
 
-
+{% set pageHeading = state.project_name %}
 {% block content %}
 
 <div class="govuk-phase-banner flex-parent-element">

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -4,7 +4,7 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/logout_partial.html" import logout_partial %}
-
+{% set pageHeading = "Flag application" %}
 {% block content %}
 <div class="govuk-phase-banner flex-parent-element">
     <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
@@ -29,7 +29,7 @@
                     <div class="govuk-grid-column-two-thirds">
                         <form method="POST">
                             {{ form.csrf_token }}
-                            <h1 class="govuk-heading govuk-heading-l">Flag application</h1>
+                            <h1 class="govuk-heading govuk-heading-l">{{pageHeading}}</h1>
                             <p class="govuk-body">
                                 Flag a section to a lead assessor. They will review the responses
                                 to either resolve your query, or stop the assessment.

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -4,7 +4,7 @@
 {%- from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/logout_partial.html" import logout_partial %}
-
+{% set pageHeading = "Resolve flag" %}
 {% block content %}
 <div class="govuk-phase-banner flex-parent-element">
   <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
@@ -27,7 +27,7 @@ flag
       <div class="govuk-grid-column-two-thirds flagging-container">
         <form method="POST">
           {{ form.csrf_token }}
-          <h1 class="govuk-heading govuk-heading-l">Resolve flag</h1>
+          <h1 class="govuk-heading govuk-heading-l">{{pageHeading}}</h1>
           {{ govukRadios({
           "id": form.resolution_flag.id,
           "name": form.resolution_flag.id,

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -9,10 +9,17 @@
 {% from "macros/comments_summary.html" import comment_summary %}
 {% from "macros/comments_box.html" import comment_box %}
 {% from "macros/logout_partial.html" import logout_partial %}
-
-
+{% set pageHeading -%}
+{# Hardcode to workaround misuse of score as a theme_id #}
+{% if current_theme_id == "score" %}
+Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
+{% elif current_theme.id == sub_criteria.id %}
+{{ sub_criteria.name }} - {{sub_criteria.project_name}}
+{% else %}
+{{current_theme.name}} - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
+{% endif %}
+{% endset %}
 {% block content %}
-
     <div class="govuk-phase-banner flex-parent-element">
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
             <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-back-link" id="back-to-assessment-overview-link">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,7 @@
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
-{% block pageTitle %}{{ service_title }}{% endblock %}
+{% block pageTitle %}{{[pageHeading.rstrip('\n'), service_title]|join(' - ') if pageHeading else service_title}}{% endblock %}
 
 {% block head %}
   {% include 'head.html' %}

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -16,3 +16,4 @@ json2html==1.3.0
 selenium==4.2.0
 webdriver-manager==3.7.0
 boto3
+beautifulsoup4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,8 @@ babel==2.11.0
     #   flask-babel
 bandit==1.7.4
     # via -r requirements-dev.in
+beautifulsoup4==4.11.2
+    # via -r requirements-dev.in
 black==22.6.0
     # via -r requirements-dev.in
 blinker==1.5
@@ -383,6 +385,8 @@ sniffio==1.2.0
     # via trio
 sortedcontainers==2.4.0
     # via trio
+soupsieve==2.3.2.post1
+    # via beautifulsoup4
 stevedore==3.5.0
     # via bandit
 swagger-ui-bundle==0.0.9

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -669,6 +669,31 @@
     "workflow_status": "NOT_STARTED",
     "short_id": "COF-123-LKMBNS"
   },
+  "assessment_store/sub_criteria_overview/app_123/business_plan": {
+    "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+    "funding_amount_requested": 0,
+    "id": "business_plan",
+    "is_scored": false,
+    "name": "Business plan",
+    "project_name": "Community Gym",
+    "short_id": "COF-123-LKMBNS",
+    "themes": [
+      {
+        "answers": [
+          {
+            "field_id": "rFXeZo",
+            "field_type": "fileUploadField",
+            "form_name": "upload-business-plan",
+            "presentation_type": "file",
+            "question": "Business plan (document upload)"
+          }
+        ],
+        "id": "business_plan",
+        "name": "Business plan"
+      }
+    ],
+    "workflow_status": "NOT_STARTED"
+  },
   "assessment_store/application_overviews/app_123": {
     "criterias": [
       {


### PR DESCRIPTION
Similar approach to https://github.com/communitiesuk/funding-service-design-frontend/pull/243 and https://github.com/communitiesuk/funding-service-design-authenticator/pull/113 to set unique `<title>` tags for pages.

* Pass through theme name to subcriteria template so it is available for title
* Some hacky code is needed to workaround `score` being set by a `theme_id`