### PR TITLE
FS-2268-bug-fix-hide-status-from-commenter

### DIFF
--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -69,8 +69,9 @@
         state.short_id,
         state.project_name,
         state.funding_amount_requested,
-        state.display_status if g.user.highest_role != "COMMENTER" else " ",
-        flag
+        state.display_status,
+        g.user.highest_role,
+        flag,
     ) }}
 
     <div class="govuk-width-container">

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -19,6 +19,7 @@ state.short_id,
 state.project_name,
 state.funding_amount_requested,
 state.display_status,
+g.user.highest_role,
 flag
 ) }}
 

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -19,7 +19,8 @@
         banner_state.short_id,
         banner_state.project_name,
         banner_state.funding_amount_requested,
-        banner_state.workflow_status
+        banner_state.workflow_status,
+        g.user.highest_role,
     ) }}
 
     <div class="govuk-width-container">

--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -1,4 +1,4 @@
-{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, display_status, flag) %}
+{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, display_status, user_role, flag) %}
 
 </div> {# This div is here on purpose. #}
 <div class="fsd-banner-background">
@@ -13,6 +13,8 @@
                         name: {{ project_name }}</h3>
                     <h3 class="govuk-body-l fsd-banner-content">Total funding requested:
                         &pound;{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
+
+                    {% if user_role != "COMMENTER" %}
                     {% if flag and flag.is_qa_complete and display_status not in ('FLAGGED', 'STOPPPED')  %}
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
                         QA complete
@@ -25,6 +27,7 @@
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
                         {{ display_status | all_caps_to_human }}
                     </h3>
+                    {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/app/assess/templates/mark_qa_complete.html
+++ b/app/assess/templates/mark_qa_complete.html
@@ -19,7 +19,8 @@
         banner_state.short_id,
         banner_state.project_name,
         banner_state.funding_amount_requested,
-        banner_state.workflow_status
+        banner_state.workflow_status,
+        g.user.highest_role,
     ) }}
 
     <div class="govuk-width-container">

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -19,6 +19,7 @@ state.short_id,
 state.project_name,
 state.funding_amount_requested,
 state.display_status,
+g.user.highest_role,
 flag
 ) }}
 <div class="govuk-width-container">

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -34,7 +34,8 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
         sub_criteria.short_id,
         sub_criteria.project_name,
         sub_criteria.funding_amount_requested,
-        sub_criteria.display_status
+        sub_criteria.display_status,
+        g.user.highest_role,
     ) }}
     <div class="govuk-width-container">
         {% if not is_flagged and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}


### PR DESCRIPTION
Hide banner status from  "COMMENTER"


Dashboard:
<img width="1505" alt="Screenshot 2023-02-07 at 16 05 00" src="https://user-images.githubusercontent.com/80714392/217300170-547c13be-97c4-47b3-bc88-1bfee37bf16e.png">

Tasklist overview:
<img width="1617" alt="Screenshot 2023-02-07 at 16 05 17" src="https://user-images.githubusercontent.com/80714392/217300123-f1d685ef-1cba-4526-a1ab-a0d3ef9d167a.png">

Scored Page:
<img width="1607" alt="Screenshot 2023-02-07 at 16 05 43" src="https://user-images.githubusercontent.com/80714392/217300096-2d59e858-f40d-49be-b2cc-28e420b50a27.png">

Unscored page:
<img width="1576" alt="Screenshot 2023-02-07 at 16 05 27" src="https://user-images.githubusercontent.com/80714392/217300112-39053b0b-ca18-44b3-8cbc-0cd30f2e5a19.png">




