### PR TITLE
FS-2294: refactor score page to own route

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -194,10 +194,18 @@ def display_sub_criteria(
     "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/score",
     methods=["POST", "GET"],
 )
+@login_required(roles_required=["LEAD_ASSESSOR", "ASSESSOR"])
 def score(
     application_id,
     sub_criteria_id,
 ):
+    sub_criteria: SubCriteria = get_sub_criteria(
+        application_id, sub_criteria_id
+    )
+
+    if not sub_criteria.is_scored:
+        abort(404)
+
     return "IN HERE"
 
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -191,6 +191,17 @@ def display_sub_criteria(
 
 
 @assess_bp.route(
+    "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/score",
+    methods=["POST", "GET"],
+)
+def score(
+    application_id,
+    sub_criteria_id,
+):
+    return "IN HERE"
+
+
+@assess_bp.route(
     "/flag/<application_id>",
     methods=["GET", "POST"],
 )

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -165,7 +165,7 @@ def display_sub_criteria(
         ]
         return render_template(
             "sub_criteria.html",
-            on_summary=True,
+            is_score_page=True,
             score_list=score_list or None,
             latest_score=latest_score,
             COF_score_list=COF_score_list,
@@ -184,7 +184,7 @@ def display_sub_criteria(
 
     return render_template(
         "sub_criteria.html",
-        on_summary=False,
+        is_score_page=False,
         answers_meta=answers_meta,
         **common_template_config,
     )
@@ -256,7 +256,7 @@ def score(
     return render_template(
         "score.html",
         application_id=application_id,
-        on_summary=True,
+        is_score_page=True,
         score_list=score_list or None,
         latest_score=latest_score,
         COF_score_list=COF_score_list,

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -255,6 +255,7 @@ def score(
     ]
     return render_template(
         "score.html",
+        application_id=application_id,
         on_summary=True,
         score_list=score_list or None,
         latest_score=latest_score,

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -133,7 +133,7 @@ def score(
 
     if not sub_criteria.is_scored:
         abort(404)
-    theme_id = request.args.get(sub_criteria.themes[0].id)
+    theme_id = sub_criteria.themes[0].id
     fund = get_fund(Config.COF_FUND_ID)
     flag = get_latest_flag(application_id)
     comments = get_comments(

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -133,13 +133,15 @@ def score(
 
     if not sub_criteria.is_scored:
         abort(404)
-    theme_id = sub_criteria.themes[0].id
     fund = get_fund(Config.COF_FUND_ID)
     flag = get_latest_flag(application_id)
     comments = get_comments(
         application_id=application_id,
         sub_criteria_id=sub_criteria_id,
-        theme_id=theme_id,
+        # Comments endpoint uses theme_id=score as a proxy to get all comments
+        # TODO: refactor endpoint so it returns all
+        # comments by default or using explicit parameter.
+        theme_id="score",
         themes=sub_criteria.themes,
     )
     # TODO: Refactor this function so it doesn't rely on side-effects

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -54,20 +54,13 @@ def display_sub_criteria(
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     theme_id = request.args.get("theme_id", sub_criteria.themes[0].id)
     comment_form = CommentsForm()
-    # We misuse the theme_id parameter to
-    # also indicate if we are on the scoring page,
-    # so we need to override to not throw an exception in that case
-    # TODO: Move Score page into separate route
-    if theme_id == "score":
-        current_theme = None
-    else:
-        try:
-            current_theme: Theme = next(
-                iter(t for t in sub_criteria.themes if t.id == theme_id)
-            )
-        except StopIteration:
-            current_app.logger.warn("Unknown theme ID requested: " + theme_id)
-            abort(404)
+    try:
+        current_theme: Theme = next(
+            iter(t for t in sub_criteria.themes if t.id == theme_id)
+        )
+    except StopIteration:
+        current_app.logger.warn("Unknown theme ID requested: " + theme_id)
+        abort(404)
     add_comment_argument = request.args.get("add_comment") == "1"
     if add_comment_argument and comment_form.validate_on_submit():
         comment = comment_form.comment.data
@@ -111,70 +104,6 @@ def display_sub_criteria(
         "current_theme": current_theme,
     }
 
-    if theme_id == "score" and sub_criteria.is_scored:
-        # SECURITY SECTION START ######
-        # Prevent non-assessors from accessing
-        # the scoring version of this page
-        if g.user.highest_role not in [
-            "LEAD_ASSESSOR",
-            "ASSESSOR",
-        ]:
-            current_app.logger.info(
-                "Non-assessor attempted to access scoring view"
-                f" {request.path}."
-            )
-            abort(404)
-        # SECURITY SECTION END ######
-
-        # Forms for scoring a sub-criteria
-        score_form = ScoreForm()
-        rescore_form = RescoreForm()
-        is_rescore = rescore_form.validate_on_submit()
-        if not is_rescore and request.method == "POST":
-            if score_form.validate_on_submit():
-                current_app.logger.info(f"Processing POST to {request.path}.")
-                score = int(score_form.score.data)
-                user_id = g.account_id
-                justification = score_form.justification.data
-                submit_score_and_justification(
-                    score=score,
-                    justification=justification,
-                    application_id=application_id,
-                    user_id=user_id,
-                    sub_criteria_id=sub_criteria_id,
-                )
-            else:
-                is_rescore = True
-
-        # call to assessment store to get latest score
-        score_list = get_score_and_justification(
-            application_id, sub_criteria_id, score_history=True
-        )
-        latest_score = (
-            score_list.pop(0)
-            if (score_list is not None and len(score_list) > 0)
-            else None
-        )
-        # TODO make COF_score_list extendable to other funds
-        COF_score_list = [
-            (5, "Strong"),
-            (4, "Good"),
-            (3, "Satisfactory"),
-            (2, "Partial"),
-            (1, "Poor"),
-        ]
-        return render_template(
-            "sub_criteria.html",
-            is_score_page=True,
-            score_list=score_list or None,
-            latest_score=latest_score,
-            COF_score_list=COF_score_list,
-            score_form=score_form,
-            rescore_form=rescore_form,
-            is_rescore=is_rescore,
-            **common_template_config,
-        )
-
     theme_answers_response = get_sub_criteria_theme_answers(
         application_id, theme_id
     )
@@ -184,7 +113,6 @@ def display_sub_criteria(
 
     return render_template(
         "sub_criteria.html",
-        is_score_page=False,
         answers_meta=answers_meta,
         **common_template_config,
     )
@@ -256,7 +184,6 @@ def score(
     return render_template(
         "score.html",
         application_id=application_id,
-        is_score_page=True,
         score_list=score_list or None,
         latest_score=latest_score,
         COF_score_list=COF_score_list,

--- a/app/assess/templates/macros/sub_criteria_navbar.html
+++ b/app/assess/templates/macros/sub_criteria_navbar.html
@@ -1,5 +1,4 @@
-{% macro navbar(application_id, sub_criteria, current_theme_id, on_summary) %}
-
+{% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False) %}
 <nav class="assessment-navigation">
     <ul class="govuk-list">
         {%for theme in sub_criteria.themes%}
@@ -10,10 +9,9 @@
     </ul>
 
 {% if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
-    {# TODO: re-write this to not use score id #}
-    {% if current_theme_id != "score" and sub_criteria.is_scored == True %}
+    {% if not is_score_page and sub_criteria.is_scored %}
     <ul class="govuk-list">
-        <li><a id="score-subcriteria-link" class="{{'govuk-link--no-underline govuk-list' if on_summary else 'govuk-link--no-visited-state'}}" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id='score') }}">Score the subcriteria</a></li>
+        <li><a id="score-subcriteria-link" class="{{'govuk-link--no-underline govuk-list' if is_score_page else 'govuk-link--no-visited-state'}}" href="{{ url_for('assess_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">Score the subcriteria</a></li>
     </ul>
     {% endif %}
 {% endif %}

--- a/app/assess/templates/macros/sub_criteria_navbar.html
+++ b/app/assess/templates/macros/sub_criteria_navbar.html
@@ -10,6 +10,7 @@
     </ul>
 
 {% if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
+    {# TODO: re-write this to not use score id #}
     {% if current_theme_id != "score" and sub_criteria.is_scored == True %}
     <ul class="govuk-list">
         <li><a id="score-subcriteria-link" class="{{'govuk-link--no-underline govuk-list' if on_summary else 'govuk-link--no-visited-state'}}" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id='score') }}">Score the subcriteria</a></li>

--- a/app/assess/templates/macros/sub_criteria_navbar.html
+++ b/app/assess/templates/macros/sub_criteria_navbar.html
@@ -1,6 +1,7 @@
 {% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False) %}
 <nav class="assessment-navigation">
     <ul class="govuk-list">
+        {# TODO: Make these unlinked if current page rather than changing link class #}
         {%for theme in sub_criteria.themes%}
         <li><a class="{{'govuk-link--no-underline govuk-list' if theme.id|string == current_theme_id|string else 'govuk-link--no-visited-state'}}"
                 href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id=theme.id) }}">{{theme.name}}</a>
@@ -9,6 +10,7 @@
     </ul>
 
 {% if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
+    {# TODO: Make this visible but un-linked on score page #}
     {% if not is_score_page and sub_criteria.is_scored %}
     <ul class="govuk-list">
         <li><a id="score-subcriteria-link" class="{{'govuk-link--no-underline govuk-list' if is_score_page else 'govuk-link--no-visited-state'}}" href="{{ url_for('assess_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">Score the subcriteria</a></li>

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -42,7 +42,7 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id, on_summary) }}
+                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
                 {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -42,7 +42,7 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page) }}
+                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page=True) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
                 {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{% from "macros/scores_justification.html" import scores_justification %}
+{% from "macros/theme.html" import theme %}
+{% from "macros/sub_criteria_navbar.html" import navbar %}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/flag_application_button.html" import flag_application_button %}
+{% from "macros/comments.html" import comment %}
+{% from "macros/comments_summary.html" import comment_summary %}
+{% from "macros/comments_box.html" import comment_box %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% set pageHeading -%}
+Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
+{% endset %}
+{% block content %}
+    <div class="govuk-phase-banner flex-parent-element">
+        <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
+            <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-back-link" id="back-to-assessment-overview-link">
+                Back to <b>assessment overview</b></a>
+        </p>
+
+        {{ logout_partial(sso_logout_url) }}
+    </div>
+
+    {{ banner_summary(
+        fund.name,
+        sub_criteria.short_id,
+        sub_criteria.project_name,
+        sub_criteria.funding_amount_requested,
+        sub_criteria.display_status
+    ) }}
+    <div class="govuk-width-container">
+        {% if not is_flagged and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
+            {{ flag_application_button(application_id) }}
+        {% endif %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third content-container">
+                <h2 class="govuk-heading-l scoring-heading">{{ sub_criteria.name }}</h2>
+            </div>
+        </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-one-third">
+                {{ navbar(application_id, sub_criteria, current_theme_id, on_summary) }}
+            </div>
+            <div class="theme govuk-grid-column-two-thirds">
+                {% if on_summary and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
+                    {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
+                {% else %}
+                    {{theme(current_theme_id, answers_meta)}}
+                {% endif %}
+                {%if current_theme_id == "score"%}
+                {{comment_summary(comments,sub_criteria.themes)}}
+                {% else %}
+                {{comment(comments)}}
+                {% endif %}
+                {% if display_comment_box != True and current_theme_id != "score" %}
+                    <a
+                        id="comment"
+                        class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
+                        type="submit"
+                        data-module="govuk-button"
+                        href="{{ url_for(
+                            "assess_bp.display_sub_criteria",
+                            application_id=application_id,
+                            sub_criteria_id=sub_criteria.id,
+                            theme_id=current_theme_id,
+                            add_comment="1",
+                            _anchor="comment"
+                        ) }}"
+                    >
+                        {% if comments == None %} Add a comment
+                        {% else %} Add another comment
+                        {% endif %}
+                    </a>
+                    {% endif %}
+
+                    {% if display_comment_box == True %}
+                        {{ comment_box(comment_form) }}
+                    {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -5,9 +5,7 @@
 {% from "macros/sub_criteria_navbar.html" import navbar %}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/flag_application_button.html" import flag_application_button %}
-{% from "macros/comments.html" import comment %}
 {% from "macros/comments_summary.html" import comment_summary %}
-{% from "macros/comments_box.html" import comment_box %}
 {% from "macros/logout_partial.html" import logout_partial %}
 {% set pageHeading -%}
 Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -45,40 +45,8 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
                 {{ navbar(application_id, sub_criteria, current_theme_id, on_summary) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
-                {% if on_summary and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
-                    {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
-                {% else %}
-                    {{theme(current_theme_id, answers_meta)}}
-                {% endif %}
-                {%if current_theme_id == "score"%}
+                {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
                 {{comment_summary(comments,sub_criteria.themes)}}
-                {% else %}
-                {{comment(comments)}}
-                {% endif %}
-                {% if display_comment_box != True and current_theme_id != "score" %}
-                    <a
-                        id="comment"
-                        class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
-                        type="submit"
-                        data-module="govuk-button"
-                        href="{{ url_for(
-                            "assess_bp.display_sub_criteria",
-                            application_id=application_id,
-                            sub_criteria_id=sub_criteria.id,
-                            theme_id=current_theme_id,
-                            add_comment="1",
-                            _anchor="comment"
-                        ) }}"
-                    >
-                        {% if comments == None %} Add a comment
-                        {% else %} Add another comment
-                        {% endif %}
-                    </a>
-                    {% endif %}
-
-                    {% if display_comment_box == True %}
-                        {{ comment_box(comment_form) }}
-                    {% endif %}
             </div>
         </div>
     </div>

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -49,7 +49,7 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page) }}
+                {{ navbar(application_id, sub_criteria, current_theme_id) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
                 {% if is_score_page and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -49,10 +49,10 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id, on_summary) }}
+                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
-                {% if on_summary and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
+                {% if is_score_page and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
                     {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
                 {% else %}
                     {{theme(current_theme_id, answers_meta)}}

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -1,19 +1,14 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
-{% from "macros/scores_justification.html" import scores_justification %}
 {% from "macros/theme.html" import theme %}
 {% from "macros/sub_criteria_navbar.html" import navbar %}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/flag_application_button.html" import flag_application_button %}
 {% from "macros/comments.html" import comment %}
-{% from "macros/comments_summary.html" import comment_summary %}
 {% from "macros/comments_box.html" import comment_box %}
 {% from "macros/logout_partial.html" import logout_partial %}
 {% set pageHeading -%}
-{# Hardcode to workaround misuse of score as a theme_id #}
-{% if current_theme_id == "score" %}
-Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
-{% elif current_theme.id == sub_criteria.id %}
+{% if current_theme.id == sub_criteria.id %}
 {{ sub_criteria.name }} - {{sub_criteria.project_name}}
 {% else %}
 {{current_theme.name}} - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
@@ -34,7 +29,8 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
         sub_criteria.short_id,
         sub_criteria.project_name,
         sub_criteria.funding_amount_requested,
-        sub_criteria.display_status
+        sub_criteria.display_status,
+        g.user.highest_role,
     ) }}
     <div class="govuk-width-container">
         {% if not is_flagged and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
@@ -52,17 +48,9 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
                 {{ navbar(application_id, sub_criteria, current_theme_id) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
-                {% if is_score_page and g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
-                    {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
-                {% else %}
-                    {{theme(current_theme_id, answers_meta)}}
-                {% endif %}
-                {%if current_theme_id == "score"%}
-                {{comment_summary(comments,sub_criteria.themes)}}
-                {% else %}
+                {{theme(current_theme_id, answers_meta)}}
                 {{comment(comments)}}
-                {% endif %}
-                {% if display_comment_box != True and current_theme_id != "score" %}
+                {% if display_comment_box != True %}
                     <a
                         id="comment"
                         class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -195,7 +195,7 @@ class TestRoutes:
 
             # Send a request to the route you want to test
             response = flask_test_client.get(
-                "/assess/application_id/app_123/sub_criteria_id/1a2b3c4d?theme_id=score"  # noqa
+                "/assess/application_id/app_123/sub_criteria_id/1a2b3c4d/score"  # noqa
             )
 
             # Assert that the response has the expected status code
@@ -254,13 +254,17 @@ class TestRoutes:
 
         # Send a request to the route you want to test
         response = flask_test_client.get(
-            "/assess/application_id/app_123/sub_criteria_id/1a2b3c4d?theme_id=score"  # noqa
+            "/assess/application_id/app_123/sub_criteria_id/1a2b3c4d/score"  # noqa
         )
 
         # Assert that the response has the expected status code
-        assert 404 == response.status_code, (
-            "Commenter should receive a 404 when trying to access the sub"
-            " criteria scoring page"
+        assert 302 == response.status_code, (
+            "Commenter should receive a 302 to authenticator when trying to"
+            " access the sub criteria scoring page"
+        )
+        assert (
+            response.location
+            == "https://authenticator/service/user?roles_required=LEAD_ASSESSOR|ASSESSOR"  # noqa
         )
 
     def test_homepage_route_accessible(self, flask_test_client):


### PR DESCRIPTION
Previously we rendered the scoring pages by overloading the `theme_id` parameter with `score`. This caused a lot of hacky workarounds and branching in templates to ensure the correct things were rendered and meant `theme_id` couldn't be safely used semantically i.e. to lookup a `Theme` class.

This moves all scoring to its own route `/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/score`

This is purely a refactor, there should be no change in any page functionality.