### PR TITLE
BAU: only make nav item link if not current page

### DIFF
--- a/app/assess/templates/macros/sub_criteria_navbar.html
+++ b/app/assess/templates/macros/sub_criteria_navbar.html
@@ -1,21 +1,33 @@
 {% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False) %}
 <nav class="assessment-navigation">
     <ul class="govuk-list">
-        {# TODO: Make these unlinked if current page rather than changing link class #}
         {%for theme in sub_criteria.themes%}
-        <li><a class="{{'govuk-link--no-underline govuk-list' if theme.id|string == current_theme_id|string else 'govuk-link--no-visited-state'}}"
-                href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id=theme.id) }}">{{theme.name}}</a>
+        {% set is_current_url = (current_theme_id == theme.id) and not is_score_page %}
+        <li>
+            {% if not is_current_url %}
+            <a class="govuk-link govuk-link--no-visited-state"
+            href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id=theme.id) }}">
+            {% endif %}
+            {{theme.name}}
+            {% if not is_current_url %}
+            </a>
+            {% endif %}
         </li>
         {%endfor%}
     </ul>
 
-{% if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] %}
-    {# TODO: Make this visible but un-linked on score page #}
-    {% if not is_score_page and sub_criteria.is_scored %}
+{% if g.user.highest_role in ["ASSESSOR","LEAD_ASSESSOR"] and sub_criteria.is_scored %}
     <ul class="govuk-list">
-        <li><a id="score-subcriteria-link" class="{{'govuk-link--no-underline govuk-list' if is_score_page else 'govuk-link--no-visited-state'}}" href="{{ url_for('assess_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">Score the subcriteria</a></li>
+        <li>
+            {% if not is_score_page %}
+            <a id="score-subcriteria-link" class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">
+            {% endif %}
+            Score the subcriteria
+            {% if not is_score_page %}
+            </a>
+            {% endif %}
+        </li>
     </ul>
-    {% endif %}
 {% endif %}
 </nav>
 


### PR DESCRIPTION
Fix TODOs added in previous story: https://github.com/communitiesuk/funding-service-design-assessment/pull/176
As-per the [prototype](https://fsd-pre-award.herokuapp.com/s26-assessment/scoring/scoring), the currently selected item in the navbar should not be a link. Also the 'Score this subcriteria' item was not appearing at all when on that page, which is also fixed by this PR.

## Screenshots 

![Screenshot 2023-02-09 at 11 21 22](https://user-images.githubusercontent.com/1764158/217799214-88919a13-1263-4d13-b7c6-80ff0cc6ec1c.png)
![Screenshot 2023-02-09 at 11 21 17](https://user-images.githubusercontent.com/1764158/217799219-683ab785-4492-434f-9f16-cbeccf4bf442.png)
