### PR TITLE
FS-2272: don't pass theme_id=score to comment endpoint on score page

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -432,22 +432,31 @@ def get_sub_criteria_theme_answers(
         abort(404, description=msg)
 
 
-def get_comments(application_id: str, sub_criteria_id: str, theme_id, themes):
-    """_summary_: Function is set up to retrieve
-    the data from application store with
-    get_data() function.
+def get_comments(
+    application_id: str, sub_criteria_id: str, theme_id: str | None, themes
+):
+    """_summary_: Get comments from the assessment store
     Args:
-        application_id: Takes an application_id, sub_criteria_id: takes a sub_criteria_id # noqa
+        application_id: application_id,
+        sub_criteria_id: sub_criteria_id
+        theme_id: optional theme_id (else returns all comments for subcriteria)
+        themes: list of subcriteria themes
     Returns:
         Returns a dictionary of comments.
     """
+    query_params = {
+        "application_id": application_id,
+        "sub_criteria_id": sub_criteria_id,
+        "theme_id": theme_id,
+    }
+    # Strip theme_id from dict if None
+    query_params_strip_nones = {
+        k: v for k, v in query_params.items() if v is not None
+    }
     comment_endpoint = (
         Config.ASSESSMENT_STORE_API_HOST
-        + Config.COMMENTS_ENDPOINT.format(
-            application_id=application_id,
-            sub_criteria_id=sub_criteria_id,
-            theme_id=theme_id,
-        )
+        + "/comment?"
+        + urlencode(query=query_params_strip_nones)
     )
 
     comment_response = get_data(comment_endpoint)

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -454,11 +454,9 @@ def get_comments(
         k: v for k, v in query_params.items() if v is not None
     }
     comment_endpoint = (
-        Config.ASSESSMENT_STORE_API_HOST
-        + "/comment?"
-        + urlencode(query=query_params_strip_nones)
+        f"{Config.ASSESSMENT_COMMENT_ENDPOINT}"
+        f"?{urlencode(query=query_params_strip_nones)}"
     )
-
     comment_response = get_data(comment_endpoint)
 
     if not comment_response or len(comment_response) == 0:

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -138,10 +138,7 @@ def score(
     comments = get_comments(
         application_id=application_id,
         sub_criteria_id=sub_criteria_id,
-        # Comments endpoint uses theme_id=score as a proxy to get all comments
-        # TODO: refactor endpoint so it returns all
-        # comments by default or using explicit parameter.
-        theme_id="score",
+        theme_id=None,
         themes=sub_criteria.themes,
     )
     # TODO: Refactor this function so it doesn't rely on side-effects

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -114,11 +114,6 @@ class DefaultConfig:
         ASSESSMENT_STORE_API_HOST + "/flag?application_id={application_id}"
     )
 
-    COMMENTS_ENDPOINT = (
-        "/comment?application_id={application_id}&sub_criteria_id="
-        "{sub_criteria_id}&theme_id={theme_id}"
-    )
-
     # Account store endpoints
     BULK_ACCOUNTS_ENDPOINT = ACCOUNT_STORE_API_HOST + "/bulk-accounts"
 

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -1215,7 +1215,7 @@
   ],
   "assessment_store/comment?application_id=app_123&sub_criteria_id=1a2b3c4d&theme_id=partnerships": [
   ],
-  "assessment_store/comment?application_id=app_123&sub_criteria_id=1a2b3c4d&theme_id=score": [
+  "assessment_store/comment?application_id=app_123&sub_criteria_id=1a2b3c4d": [
     {
       "comment": "This is a comment",
       "user_id": "0a31fa06-7555-11ed-a1eb-0242ac120002",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -205,6 +205,7 @@ class TestRoutes:
                 soup.title.string
                 == "Score - Engagement - Community Gym - Assessment Hub"
             )
+            assert b"This is a comment" in response.data
 
             # Assert that the response contains the expected ids
             assert (


### PR DESCRIPTION
Now that https://github.com/communitiesuk/funding-service-design-assessment-store/pull/123 has been merged and deployed we no longer need to pass `theme_id=score` to the comments endpoint.

This also refactors how the URL is built so we can strip the parameter from the generated query string if `None`. 