### PR TITLE
tagging action permissions update

### DIFF
--- a/.github/workflows/s3-zip.yaml
+++ b/.github/workflows/s3-zip.yaml
@@ -1,4 +1,6 @@
 name: Tag-zip release
+permissions:
+  contents: write
 on:
   pull_request:
     types:


### PR DESCRIPTION
Change description
Since moving to an Enterprise org it appears GITHUB_TOKEN has defaulted to restricted permissions as described in https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token so we need to specify the correct permissions for our workflows.

[ - ] Unit tests and other appropriate tests added or updated
[ - ] README and other documentation has been updated / added (if needed)
[ - ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
How to test
If manual testing is needed, give suggested testing steps

Screenshots of UI changes (if applicable)