### PR TITLE
FS-2371: Fix for duplicate ids in bulk-accounts endpoint

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -180,7 +180,7 @@ def get_round_with_applications(
 
 def get_bulk_accounts_dict(account_ids: List):
     account_url = Config.BULK_ACCOUNTS_ENDPOINT
-    account_params = {"account_id": account_ids}
+    account_params = {"account_id": list(set(account_ids))}
     return get_data(account_url, account_params)
 
 


### PR DESCRIPTION
### Change description

When making the request for bulk-accounts, we unnecessarily send the same ids lots of times, by putting it into a set then back to a list, we can ensure each id is only sent once.

```python
list(set(['a', 'a', 'b'])) # ['b', 'a']
```

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### How to test

N/A - This is a quick tiny fix to delay the issue from re-occurring on from e2e tests, but in theory it could still happen if lots of unique users were to comment on the same application, so I think it would be good to change it from using query parameters based on that, although that's a lot less likely to occur after we de-duplicate the ids.   More info on the [JIRA](https://digital.dclg.gov.uk/jira/browse/FS-2371).
