### PR TITLE
BAU-export-file-empty-answer-key-bug-fix

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -542,7 +542,7 @@ def get_files_for_application_upload_fields(
     for form in forms:
         for question in form[NotifyConstants.APPLICATION_QUESTIONS_FIELD]:
             for field in question["fields"]:
-                if field["type"] == "file":
+                if field["type"] == "file" and field.get("answer"):
                     file_names.append(field["answer"])
 
     files = [

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -312,6 +312,24 @@ single_application_json_blob = {
             "status": "COMPLETED",
         },
         {
+            "name": "upload-no-plan",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            # Intentionally missing "answer" key for testing
+                            "key": "rFXeZo",
+                            "title": "Upload NO plan",
+                            "type": "file",
+                        }
+                    ],
+                    "question": "Management case",
+                    "status": "COMPLETED",
+                }
+            ],
+            "status": "COMPLETED",
+        },
+        {
             "name": "project-information",
             "questions": [
                 {

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from app.assess.data import get_files_for_application_upload_fields
 from app.assess.helpers import extract_questions_and_answers_from_json_blob
 from app.assess.helpers import generate_text_of_application
 from tests.api_data.test_data import single_application_json_blob
@@ -41,3 +44,22 @@ class TestExport:
         assert "********* Community Ownership Fund" in result
         assert "Q) Capital funding" in result
         assert "A) 2300" in result
+
+    def test_get_files_for_application_upload_fields(self):
+        application_id = "dummy_id"
+        short_id = "d_id"
+
+        with mock.patch(
+            "app.assess.data.url_for",
+            return_value="dummy/path/to/file.dmp",
+        ):
+            ans = get_files_for_application_upload_fields(
+                application_id,
+                short_id,
+                {"jsonb_blob": single_application_json_blob},
+            )
+
+        assert ans == [
+            ("sample1.doc", "dummy/path/to/file.dmp"),
+            ("awskey123123123123123/sample1.doc", "dummy/path/to/file.dmp"),
+        ]


### PR DESCRIPTION
### Change description
Sentry raised [this](https://funding-service-design-team-dl.sentry.io/issues/4027062124/?referrer=slack) error as the export file functionality was tripping over generating the file names for an application. This was caused by a key error being raised if a file field had no answer (i.e. user had not submitted a file for an optional file-upload field). We have now added a check to only generate the list of file names for file-upload fields with an answer in this PR.

- [ ✅ ] Unit tests and other appropriate tests added or updated
- [ 🔕 ] README and other documentation has been updated / added (if needed)
- [ ✅ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
New test to catch this in the future can be found in tests/test_export.py (line 48) and the test data used can be found in  tests/api_data/test_data.py (line 95, 315)
