### PR TITLE
Fs 2388 - Replace ids with data-qa (for e2e tests) 

### DIFF
--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -17,7 +17,7 @@
 
 <div class="govuk-phase-banner flex-parent-element">
     <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
-        {{ govukBackLink({'href': url_for("assess_bp.landing"), 'html': 'Back to <b>assessment dashboard</b>', 'attributes': {'id': 'back-to-assessment-dashboard'}}) }}
+        {{ govukBackLink({'href': url_for("assess_bp.landing"), 'html': 'Back to <b>assessment dashboard</b>', 'attributes': {'data-qa': 'back-to-assessment-dashboard'}}) }}
     </p>
 
     {{ logout_partial(sso_logout_url) }}

--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -106,7 +106,7 @@
             <tr class="govuk-table__row">
 
                 <td class="govuk-table__cell">{{overview.short_id[-6:]}}</td>
-                <td class="govuk-table__cell"><a class="govuk-link" id="project_name" href="{{url_for('assess_bp.application',application_id=overview.application_id)}}">{{overview.project_name}}</a></td>
+                <td class="govuk-table__cell"><a class="govuk-link" data-qa="project_name" href="{{url_for('assess_bp.application',application_id=overview.application_id)}}">{{overview.project_name}}</a></td>
                 <td class="govuk-table__cell">{{asset_types[overview.asset_type]}}</td>
                 <td class="govuk-table__cell">&pound;{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
                 <td class="govuk-table__cell">{{ overview.location_json_blob.country}}</td>

--- a/app/assess/templates/macros/criteria_element.html
+++ b/app/assess/templates/macros/criteria_element.html
@@ -5,7 +5,7 @@
     {% for sub_criteria in criteria.sub_criterias %}
         {% set _ = rows.append([
             {
-                "html": '<a class="govuk-link" id="sub_criteria_name" href="{}">{}</a>'.format(
+                "html": '<a class="govuk-link" data-qa="sub_criteria_name" href="{}">{}</a>'.format(
                     url_for(
                         'assess_bp.display_sub_criteria',
                          application_id=application_id,

--- a/app/assess/templates/macros/section_element.html
+++ b/app/assess/templates/macros/section_element.html
@@ -5,7 +5,7 @@
     {% for sub_criteria in sub_criterias %}
         {% set _ = rows.append([
             {
-                'html': '<a class="govuk-link" id="sub_criteria_name" href="{}">{}</a>'.format(
+                'html': '<a class="govuk-link" data-qa="sub_criteria_name" href="{}">{}</a>'.format(
                     url_for(
                         'assess_bp.display_sub_criteria',
                          application_id=application_id,

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -17,7 +17,7 @@
 {% block content %}
     <div class="govuk-phase-banner flex-parent-element">
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
-            <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-back-link" id="back-to-assessment-overview-link">
+            <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-back-link" data-qa="back-to-assessment-overview-link">
                 Back to <b>assessment overview</b></a>
         </p>
 


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2388


### Change description

There were two accessibility violations against the Assessor dashboard and Assessment overview page where the same ids were not unique in those pages. These ids were used for the e2e test selectors. I have now replaced them with the data-qa attribute and they now meet WCAG 2.1 A standards. 

https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes


A separate PR has been raised in the e2e repo to update the selectors from IDs to data-qa. 


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_

Run axe dev tools against the Assessor dashboard and Assessment overview page. 


### Screenshots of UI changes (if applicable)

N/A
