### PR TITLE
remove redundant heading

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -103,7 +103,6 @@ def display_sub_criteria(
         sub_criteria.workflow_status, flag
     )
     common_template_config = {
-        "current_theme_id": theme_id,
         "sub_criteria": sub_criteria,
         "application_id": application_id,
         "fund": fund,

--- a/app/assess/templates/macros/theme.html
+++ b/app/assess/templates/macros/theme.html
@@ -16,8 +16,7 @@
     'question_heading': question_heading,
 } %}
 
-{% macro theme(theme_id, answers_meta) %}
-    <h2 class="govuk-heading-m">{{ theme_id | remove_dashes_underscores_capitalize }}</h2>
+{% macro theme(answers_meta) %}
     <h3 class="govuk-heading-s response-title">Applicant's response</h3>
     <div class="template-answer bg-white">
         {% for meta in answers_meta %}

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -63,10 +63,10 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id) }}
+                {{ navbar(application_id, sub_criteria, current_theme.id) }}
             </div>
             <div class="theme govuk-grid-column-two-thirds">
-                {{theme(current_theme_id, answers_meta)}}
+                {{theme(answers_meta)}}
                 {{comment(comments)}}
                 {% if display_comment_box != True %}
                     <a
@@ -78,7 +78,7 @@
                             "assess_bp.display_sub_criteria",
                             application_id=application_id,
                             sub_criteria_id=sub_criteria.id,
-                            theme_id=current_theme_id,
+                            theme_id=current_theme.id,
                             add_comment="1",
                             _anchor="comment"
                         ) }}"

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -491,7 +491,7 @@ class TestJinjaMacros(object):
         meta = clazz.from_dict(**arguments)
 
         rendered_html = render_template_string(
-            "{{ theme('a-theme-id', [meta]) }}",
+            "{{ theme([meta]) }}",
             theme=get_template_attribute("macros/theme.html", "theme"),
             meta=meta,
         )


### PR DESCRIPTION
Accessibility - Non-descriptive heading (Medium priority)
[FS-2323](https://digital.dclg.gov.uk/jira/browse/FS-2323)

### Change description
Sub criteria page has duplicated  headings at level 2 (‘Declarations’ and Business case). This issue may cause difficulty for screen reader users who use headings to navigate and identify different sections of information on the page. All headings should be unique and descriptive, this allows users to identify and navigate to each section of the page when using the headings dialog list.

Solution:
Ensure all headings are unique and descriptive. In this case, remove the second h2 heading‘Declarations’to ensure a logical and hierarchical heading structure is preserved.


### Screenshots of UI changes (if applicable)
BEFORE
![image](https://user-images.githubusercontent.com/95699325/229490834-b18a4422-6803-4138-ad5f-45d6b0a3a7bc.png)


*Tests updated to reflect template changes


AFTER
![image](https://user-images.githubusercontent.com/95699325/229491152-1a5b896b-a325-4335-862c-7bb74d99c900.png)
