### PR TITLE
fix the display status in sub criteria

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -108,7 +108,7 @@ def display_sub_criteria(
         "application_id": application_id,
         "fund": fund,
         "comments": comments,
-        "is_flagged": bool(flag),
+        "flag": flag,
         "display_comment_box": add_comment_argument,
         "comment_form": comment_form,
         "current_theme": current_theme,
@@ -395,7 +395,8 @@ def application(application_id):
         application_id=application_id,
         flag=flag,
         current_user_role=g.user.highest_role,
-        flag_user_info=accounts.get(flag.user_id) if flag else None,
+        flag_user_info=accounts.get(flag.user_id) if (
+            flag and accounts) else None,
         is_flaggable=is_flaggable(flag),
         display_status=display_status,
     )

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -395,8 +395,9 @@ def application(application_id):
         application_id=application_id,
         flag=flag,
         current_user_role=g.user.highest_role,
-        flag_user_info=accounts.get(flag.user_id) if (
-            flag and accounts) else None,
+        flag_user_info=accounts.get(flag.user_id)
+        if (flag and accounts)
+        else None,
         is_flaggable=is_flaggable(flag),
         display_status=display_status,
     )

--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -15,7 +15,7 @@
                         &pound;{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
 
                     {% if user_role != "COMMENTER" %}
-                    {% if flag and flag.is_qa_complete and display_status not in ('FLAGGED', 'STOPPPED')  %}
+                    {% if flag and flag.is_qa_complete and display_status not in ('FLAGGED', 'STOPPED')  %}
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
                         QA complete
                     </h3>

--- a/app/assess/templates/sub_criteria.html
+++ b/app/assess/templates/sub_criteria.html
@@ -49,9 +49,10 @@
         sub_criteria.funding_amount_requested,
         display_status,
         g.user.highest_role,
+        flag
     ) }}
     <div class="govuk-width-container">
-        {% if not is_flagged and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
+        {% if not flag and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
             {{ flag_application_button(application_id) }}
         {% endif %}
         <div class="govuk-grid-row">


### PR DESCRIPTION
FS-2347 Resolve QA Complete status for sub criteria sections

### Description
Fixed the bug - The status in the sub criteria pages is showing "Assessment complete" when the actual status is "QA Complete".
Unit tests are checked & passed..

### How to test
1. Login to Assessment
2. Complete assessment for an application 
3. Mark the assessment as QA complete
4. Flag the application 
5. Resolve the flag as Query resolved
6. Click on any of the sub criteria pages and observe


### Screenshots of UI changes (if applicable)
![image](https://user-images.githubusercontent.com/127315890/230026948-e4043035-797c-4937-b999-6956f08718ba.png)

