### PR TITLE
added error box for missing pages

### DIFF
--- a/app/assess/forms/continue_application_form.py
+++ b/app/assess/forms/continue_application_form.py
@@ -1,10 +1,16 @@
+from config import Config
 from flask_wtf import FlaskForm
 from wtforms import TextAreaField
-from wtforms.validators import InputRequired
+from wtforms.validators import (InputRequired, length)
 
 
 class ContinueApplicationForm(FlaskForm):
     reason = TextAreaField(
         "reason",
-        validators=[InputRequired()],
+        validators=[
+            length(max=Config.TEXT_AREA_INPUT_MAX_CHARACTERS),
+            InputRequired(
+                message="Provide a reason for continuing assessment"
+            ),
+        ],
     )

--- a/app/assess/forms/continue_application_form.py
+++ b/app/assess/forms/continue_application_form.py
@@ -1,7 +1,8 @@
 from config import Config
 from flask_wtf import FlaskForm
 from wtforms import TextAreaField
-from wtforms.validators import (InputRequired, length)
+from wtforms.validators import InputRequired
+from wtforms.validators import length
 
 
 class ContinueApplicationForm(FlaskForm):

--- a/app/assess/forms/resolve_flag_form.py
+++ b/app/assess/forms/resolve_flag_form.py
@@ -10,12 +10,12 @@ class ResolveFlagForm(FlaskForm):
     resolution_flag = RadioField(
         "resolve",
         choices=["RESOLVED", "STOPPED"],
-        validators=[InputRequired()],
+        validators=[InputRequired(message="Select a resolution")],
     )
     justification = TextAreaField(
         "justification",
         validators=[
-            InputRequired(),
+            InputRequired(message="Provide a reason for resolving the flag"),
             length(max=Config.TEXT_AREA_INPUT_MAX_CHARACTERS),
         ],
     )

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -13,6 +13,25 @@
     </p>
     {{ logout_partial(sso_logout_url) }}
 </div>
+
+{% if form.errors.get("reason") %}
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+    <div role="alert">
+        <h2 class="govuk-error-summary__title">
+            There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+                <li>
+                    <a href=#{{form.reason.id}}>Reason for continuing assessment</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+
 {{ banner_summary(
 fund_name,
 state.short_id,

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -23,7 +23,7 @@
         <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
                 <li>
-                    <a href=#{{form.reason.id}}>Reason for continuing assessment</a>
+                    <a href=#{{form.reason.id}}>{{form.errors.get("reason") | join("\n")}}</a>
                 </li>
             </ul>
         </div>

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -14,6 +14,32 @@
 
     {{ logout_partial(sso_logout_url) }}
 </div>
+
+{% if form.errors.get("justification") or form.errors.get("section") %}
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+    <div role="alert">
+        <h2 class="govuk-error-summary__title">
+            There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+                {% if form.errors.get("justification") %}
+                <li>
+                    <a href=#{{form.justification.id}}>Reason for flagging</a>
+                </li>
+                {% endif %}
+                {% if form.errors.get("section") %}
+                <li>
+                    <a href=#{{form.section.id}}>Section to flag</a>
+                </li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+
     {{ banner_summary(
         fund_name,
         banner_state.short_id,

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -25,12 +25,12 @@
             <ul class="govuk-list govuk-error-summary__list">
                 {% if form.errors.get("justification") %}
                 <li>
-                    <a href=#{{form.justification.id}}>Reason for flagging</a>
+                    <a href=#{{form.justification.id}}>{{form.errors.get("justification") | join("\n")}}</a>
                 </li>
                 {% endif %}
                 {% if form.errors.get("section") %}
                 <li>
-                    <a href=#{{form.section.id}}>Section to flag</a>
+                    <a href=#{{form.section.id}}>{{form.errors.get("section") | join("\n")}}</a>
                 </li>
                 {% endif %}
             </ul>

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -24,12 +24,12 @@
       <ul class="govuk-list govuk-error-summary__list">
         {% if form.errors.get(form.resolution_flag.id) %}
         <li>
-          <a href=#{{form.resolution_flag.id}}>This field is required.</a>
+          <a href=#{{form.resolution_flag.id}}>{{form.errors.get(form.resolution_flag.id) | join("\n")}}</a>
         </li>
         {% endif %}
         {% if form.errors.get("justification") %}
         <li>
-          <a href=#{{form.justification.id}}>This field is required.</a>
+          <a href=#{{form.justification.id}}>{{form.errors.get("justification") | join("\n")}}</a>
         </li>
         {% endif %}
       </ul>

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -13,6 +13,32 @@
 </p>
   {{ logout_partial(sso_logout_url) }}
 </div>
+
+{% if form.errors.get(form.resolution_flag.id) or form.errors.get("justification") %}
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        {% if form.errors.get(form.resolution_flag.id) %}
+        <li>
+          <a href=#{{form.resolution_flag.id}}>This field is required.</a>
+        </li>
+        {% endif %}
+        {% if form.errors.get("justification") %}
+        <li>
+          <a href=#{{form.justification.id}}>This field is required.</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+
 {{ banner_summary(
 fund_name,
 state.short_id,


### PR DESCRIPTION
The issue on JIRA
https://digital.dclg.gov.uk/jira/browse/FS-2376


### Description
- Fixed missing error boxes for certain pages
- Unit tests are checked & passed

### How to test
- Visit the below pages & click submit without selecting any option or adding data in the fields.
- Error box should appear on the top of the page


### Screenshots of UI changes (if applicable)
![image](https://user-images.githubusercontent.com/127315890/230311913-0a050aa2-3821-4e4e-9ad6-f4c5729708dc.png)

![image](https://user-images.githubusercontent.com/127315890/230312688-5df77b96-1be0-413c-bec9-aa23fdc43300.png)

![image](https://user-images.githubusercontent.com/127315890/230312766-bc0913d7-8e58-4882-b083-88648b3dd717.png)


