### PR TITLE
Fs 2344 fix display status in export page

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -259,6 +259,7 @@ def flag(application_id):
         "flag_application.html",
         application_id=application_id,
         fund_name=fund.name,
+        flag = flag,
         banner_state=banner_state,
         form=form,
         referrer=request.referrer,
@@ -493,6 +494,7 @@ def generate_doc_list_for_download(application_id):
     )
 
     fund = get_fund(state.fund_id)
+    flag = get_latest_flag(application_id)
     application_json = get_application_json(application_id)
     supporting_evidence = get_files_for_application_upload_fields(
         application_id=application_id,
@@ -516,6 +518,7 @@ def generate_doc_list_for_download(application_id):
         application_answers=application_answers,
         supporting_evidence=supporting_evidence,
         display_status=display_status,
+        flag=flag,
     )
 
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -262,7 +262,11 @@ def flag(application_id):
         flag = flag,
         banner_state=banner_state,
         form=form,
-        referrer=request.referrer,
+        referrer=url_for(
+                    "assess_bp.application",
+                    application_id=application_id,
+                    _external =True
+                ),
     )
 
 

--- a/app/assess/templates/contract_downloads.html
+++ b/app/assess/templates/contract_downloads.html
@@ -20,6 +20,7 @@ state.short_id,
 state.project_name,
 state.funding_amount_requested,
 display_status,
+g.user.highest_role,
 flag
 ) }}
 

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -47,6 +47,7 @@
         banner_state.funding_amount_requested,
         banner_state.workflow_status,
         g.user.highest_role,
+        flag
     ) }}
 
     <div class="govuk-width-container">


### PR DESCRIPTION
This PR has fixes for the following bugs
https://digital.dclg.gov.uk/jira/browse/FS-2344
https://digital.dclg.gov.uk/jira/browse/FS-2373


### Description
- Fixed display status for export page(FS-2344) 
- Fixed page redirect when clicked on cancel button in flag page
-  Unit tests are checked & passed.

### How to test
Look at the Jira tickets description

