### PR TITLE
redirect to assess_bp page when cancel is clicked

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -262,11 +262,7 @@ def flag(application_id):
         flag=flag,
         banner_state=banner_state,
         form=form,
-        referrer=url_for(
-            "assess_bp.application",
-            application_id=application_id,
-            _external=True,
-        ),
+        referrer=request.referrer,
     )
 
 

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -73,7 +73,7 @@ flag
                         <button class="govuk-button primary-button" data-module="govuk-button">
                             Submit
                         </button>
-                        <a href="{{ referrer }}" class="govuk-button secondary-button govuk-link--no-visited-state">
+                        <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-button secondary-button govuk-link--no-visited-state">
                             Cancel
                         </a>
                     </div>

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -96,7 +96,7 @@
                                         data-module="govuk-button">
                                     Submit
                                 </button>
-                                <a href="{{ referrer }}"
+                                <a href="{{url_for('assess_bp.application', application_id=application_id)}}"
                                    class="govuk-button secondary-button">
                                     Cancel
                                 </a>


### PR DESCRIPTION
Jira Issue Link
https://digital.dclg.gov.uk/jira/browse/FS-2373

### Description
Made to redirect to assessment application overview page when clicked on cancel button

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
look at the description in jira ticket
