### PR TITLE
add accessibility tags to elements

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -31,7 +31,7 @@
                         {% endif %}
                         <h2 class="govuk-heading-l fsd-banner-content">All active assessments</h2>
                         <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding"><strong>Fund: </strong>{{round_details["fund_name"]}}</h3>
-                        <h3 class="govuk-body-l fsd-banner-content"><strong>Round:</strong>{{round_details["round_title"]}}</h3>
+                        <h3 class="govuk-body-l fsd-banner-content"><strong>Round: </strong>{{round_details["round_title"]}}</h3>
                     </div>
                 </div>
             </div>

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -36,8 +36,8 @@
     {% if state.workflow_status=="COMPLETED" and current_user_role != "COMMENTER" and not flag.is_qa_complete %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <div class="assessment-complete  govuk-margin-bottom-8">
-                    <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">
+                <div class="assessment-complete  govuk-margin-bottom-8" role="alert">
+                    <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4" autofocus>
                         Assessment complete</h2>
                     <p class="govuk-body">You have marked this assessment as complete.</p>
                     <p class="govuk-body">
@@ -54,7 +54,7 @@
         {{ form.csrf_token }}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <div class="assessment-alert  govuk-margin-bottom-8">
+                <div class="assessment-alert  govuk-margin-bottom-8" role="alert">
                     <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">All sections assessed</h2>
                     <p class="govuk-body">You can now mark the assessment as complete when you're ready.</p>
                     <p class="govuk-body">It may be selected for quality assurance (QA) once you've done this.</p>

--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -54,14 +54,16 @@
 </div>
 
 {% if not application_overviews %}
-<p class="govuk-body">
-  <strong>No matching results.</strong>
-</p>
-<p class="govuk-body">Improve your results by:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>removing filters</li>
-  <li>double-checking your spelling</li>
-</ul>
+<div role="status" aria-live="assertive">
+  <p class="govuk-body" autofocus>
+    <strong>No matching results.</strong>
+  </p>
+  <p class="govuk-body">Improve your results by:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>removing filters</li>
+    <li>double-checking your spelling</li>
+  </ul>
+</div>
 {% else %}
 <table class="govuk-table" id="application_overviews_table">
 

--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -1,5 +1,5 @@
 {% macro assessment_flagged(flag, user_info, application_id, current_user_role) %}
-    <div class="assessment-alert assessment-alert--flagged">
+    <div class="assessment-alert assessment-alert--flagged" role="alert">
         <h1 class="assessment-alert__heading govuk-heading-l">
             {{ flag.flag_type.name | title }}
         </h1>
@@ -16,7 +16,7 @@
 {% endmacro %}
 
 {% macro assessment_stopped(flag, user_info, application_id, current_user_role) %}
-    <div class="assessment-alert assessment-alert--stopped">
+    <div class="assessment-alert assessment-alert--stopped" role="alert">
         <h1 class="assessment-alert__heading govuk-heading-l">Assessment {{ flag.flag_type.name | title }}</h1>
         <h2 class="govuk-heading-m">Reason</h2>
         <p class="govuk-body">{{ flag.justification }}</p>

--- a/app/assess/templates/macros/qa_complete_flag.html
+++ b/app/assess/templates/macros/qa_complete_flag.html
@@ -4,7 +4,7 @@
 {% macro qa_complete_flag(flag, user_info, csrf_token, application_id, current_user_role) %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <div class="assessment-complete  govuk-margin-bottom-8">
+        <div class="assessment-complete  govuk-margin-bottom-8" role="alert">
             <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">
                 Marked as QA complete </h2>
                 <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>

--- a/app/assess/templates/macros/scores.html
+++ b/app/assess/templates/macros/scores.html
@@ -1,7 +1,6 @@
 {%- from 'govuk_frontend_jinja/components/radios/macro.html' import govukRadios -%}
 
 {% macro scores(form, score_list) %}
-
 <p class="govuk-body">Select a score from the list:&nbsp;</p>
 <div class="govuk-form-group {% if form.errors.get('score') %}govuk-form-group--error{% endif %}" name="score-div" id="score-div">
     {% if form.errors.get("score") %}

--- a/app/assess/templates/macros/scores_justification.html
+++ b/app/assess/templates/macros/scores_justification.html
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-column-full s26-scoring">
     {% if latest_score %}
-    <div class="score-group" id="score">
+    <div class="score-group" id="score" role="status">
         <h2 class="govuk-heading-m">Current score: {{ latest_score['score'] }}</h2>
         <div>
             <p class="govuk-body-m"><strong>Rationale: </strong>{{ latest_score.justification }}</p>

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -9,9 +9,9 @@
 {% from "macros/logout_partial.html" import logout_partial %}
 {% set pageHeading -%}
 {% if score_form.errors.get('score') or score_form.errors.get('justification') %}
-    Error:
+Error:
 {% endif %}
-    Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
+Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
 {% endset %}
 
 {% block content %}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -8,9 +8,14 @@
 {% from "macros/comments_summary.html" import comment_summary %}
 {% from "macros/logout_partial.html" import logout_partial %}
 {% set pageHeading -%}
-Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
+{% if score_form.errors.get('score') or score_form.errors.get('justification') %}
+    Error:
+{% endif %}
+    Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
 {% endset %}
+
 {% block content %}
+
     <div class="govuk-phase-banner flex-parent-element">
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
             <a href="{{url_for('assess_bp.application', application_id=application_id)}}" class="govuk-back-link" data-qa="back-to-assessment-overview-link">
@@ -21,29 +26,28 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
     </div>
 
     {% if score_form.errors.get('score') or score_form.errors.get('justification') %}
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                <h2 class="govuk-error-summary__title">
-                    There is a problem
-                </h2>
-                <div class="govuk-error-summary__body">
-                    <ul class="govuk-list govuk-error-summary__list">
-                        {% if score_form.errors.get('score') %}
-                            <li>
-                                <a href="#score-div">Select a score</a>
-                            </li>
-                        {% endif %}
-                        {% if score_form.errors.get('justification') %}
-                            <li>
-                                <a href="#just-text-area">Add rationale for score</a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </div>
-                </div>
+    <div class="govuk-width-container">
+        <div class="govuk-grid-row govuk-error-summary " data-module="govuk-error-summary" role="alert">
+            <h2 class="govuk-error-summary__title" autofocus>
+                There is a problem
+            </h2>
+            <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                    {% if score_form.errors.get('score') %}
+                        <li>
+                            <a href="#score-div">Select a score</a>
+                        </li>
+                    {% endif %}
+                    {% if score_form.errors.get('justification') %}
+                        <li>
+                            <a href="#just-text-area">Add rationale for score</a>
+                        </li>
+                    {% endif %}
+                </ul>
             </div>
-        {% endif %}
-
+        </div>
+    </div>
+    {% endif %}
 
     {{ banner_summary(
         fund.name,
@@ -52,6 +56,7 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
         sub_criteria.funding_amount_requested,
         display_status
     ) }}
+
     <div class="govuk-width-container">
         {% if is_flaggable and g.user.highest_role in ("ASSESSOR", "LEAD_ASSESSOR") %}
             {{ flag_application_button(application_id) }}
@@ -62,16 +67,16 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
             </div>
         </div>
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-grid-column-one-third">
-                {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page=True) }}
-            </div>
-            <div class="theme govuk-grid-column-two-thirds">
-                {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
-                {{comment_summary(comments,sub_criteria.themes)}}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-one-third">
+                    {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page=True) }}
+                </div>
+                <div class="theme govuk-grid-column-two-thirds">
+                    {{scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria.id, COF_score_list)}}
+                    {{comment_summary(comments,sub_criteria.themes)}}
+                </div>
             </div>
         </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,12 +4,8 @@
 
 {% block pageTitle %}{{[pageHeading.rstrip('\n'), service_title]|join(' - ') if pageHeading else service_title}}{% endblock %}
 
-{% block head %}
-  {% include 'head.html' %}
-{% endblock %}
-
 {% block header %}
-  {% include 'header.html' %}
+  {% include 'head.html' %}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2322
The DAC Accessibility Report (attached) reported that status messages could not be programmatically determined through role or properties in order that they could be presented to users by assistive technologies without receiving focus.

### Change description
_A brief description of the pull request_
When no results are returned, place the results information inside a separate div and use the role of ‘status’ on the <div> which will inform screen reader users of the change in status on the page. Using role=status to present status messages.

When scoring validation fails, use an error summary on the page which contains a h2 heading ‘There is a problem’ and uses the role of alert to inform screen reader users that there are errors on the page with skip links to direct users to the input fields in error. Additionally, ensure when the page title updates, it contains the word ‘Error:’ before the page title

Add the role of ‘status’ to the div which contains the score information added to the page. This will enable screen reader users to identify the information and be given the opportunity to re-score the sub criteria.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### Screenshots of UI changes (if applicable)
<img width="514" alt="image" src="https://user-images.githubusercontent.com/95699325/231408348-0297c91d-07ab-4d40-8335-e9b2bdea0956.png">
