### PR TITLE
FS-2577 - Add data attribute to view assessments link in Assessor Dashboard Tool

### DIFF
--- a/app/assess/templates/macros/fund_dashboard_summary.html
+++ b/app/assess/templates/macros/fund_dashboard_summary.html
@@ -34,7 +34,7 @@
             ],
             }) }}
 
-            <a class="govuk-link" href="{{ assessments_href }}">
+            <a class="govuk-link" data-qa="dashboard_summary" href="{{ assessments_href }}">
                 View all {% if is_active_status %}active{% else %}
                 closed{% endif %} assessments
             </a>


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2577
https://digital.dclg.gov.uk/jira/browse/FS-2567



### Change description
Added data attribute to enable the e2e tests for Assessment to click on the view assessments link in the Assessor Dashboard Tool.


### How to test
Run e2e tests locally by running `npx wdio run ./wdio.conf.js --suite assessment_lead_assessor` for Lead Assessor e2e journey or
`npx wdio run ./wdio.conf.js --suite assessment_assessor` for Assessor e2e journey 


### Screenshots of UI changes (if applicable)
N/A
