### PR TITLE
FS-2548-2572-bug-fix-subcriteria-scoring-status

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -296,6 +296,7 @@ def qa_complete(application_id):
 
     banner_state = get_banner_state(application_id)
     fund = get_fund(banner_state.fund_id)
+    flag = get_latest_flag(application_id)
 
     return render_template(
         "mark_qa_complete.html",
@@ -304,6 +305,7 @@ def qa_complete(application_id):
         banner_state=banner_state,
         form=form,
         referrer=request.referrer,
+        flag=flag,
     )
 
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -221,6 +221,7 @@ def score(
         fund=fund,
         comments=theme_matched_comments,
         display_status=display_status,
+        flag=flag,
         is_flaggable=is_flaggable(flag),
     )
 

--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -15,10 +15,16 @@
                         &pound;{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
 
                     {% if user_role != "COMMENTER" %}
-                    {% if flag and flag.is_qa_complete and display_status not in ('FLAGGED', 'STOPPED')  %}
+                    {% if flag and flag.is_qa_complete and display_status not in ('FLAGGED', 'STOPPED') %}
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
                         QA complete
                     </h3>
+
+                    {% elif flag and not flag.is_qa_complete and flag.flag_type.name == 'FLAGGED' %}
+                    <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
+                        Flagged
+                    </h3>
+
                     {% elif display_status=='COMPLETED' %}
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">
                         Assessment complete

--- a/app/assess/templates/mark_qa_complete.html
+++ b/app/assess/templates/mark_qa_complete.html
@@ -21,6 +21,7 @@
         banner_state.funding_amount_requested,
         banner_state.workflow_status,
         g.user.highest_role,
+        flag
     ) }}
 
     <div class="govuk-width-container">

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -54,7 +54,9 @@ Score - {{ sub_criteria.name }} - {{sub_criteria.project_name}}
         sub_criteria.short_id,
         sub_criteria.project_name,
         sub_criteria.funding_amount_requested,
-        display_status
+        display_status,
+        g.user.highest_role,
+        flag
     ) }}
 
     <div class="govuk-width-container">


### PR DESCRIPTION
This super tiny PR resolves a small bug related to the banner status of the subcriteria scoring page.

- FS-2548: The incorrect display of status when the application was flagged as QA COMPLETED, where "Assessment complete" was shown instead of "QA complete".
- FS-2572: The QA complete status was not displayed in the correct format. 
