### PR TITLE
FS-2651: Add data qa attribute to sub criteria theme link

### DIFF
--- a/app/assess/templates/macros/sub_criteria_navbar.html
+++ b/app/assess/templates/macros/sub_criteria_navbar.html
@@ -5,7 +5,7 @@
         {% set is_current_url = (current_theme_id == theme.id) and not is_score_page %}
         <li>
             {% if not is_current_url %}
-            <a class="govuk-link govuk-link--no-visited-state"
+            <a class="govuk-link govuk-link--no-visited-state" data-qa="sub_criteria_theme"
             href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id,sub_criteria_id=sub_criteria.id,theme_id=theme.id) }}">
             {% endif %}
             {{theme.name}}


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2651


### Change description

Added data qa attribute to the sub criteria theme link to ensure that the e2e test for commenters in assessment can interact with the link easily. 


### How to test
Once this PR is merged run `npx wdio run ./wdio.conf.js --suite assessment_commenter` locally and the test should pass. 

### Screenshots of UI changes (if applicable)

N/A
