### PR TITLE
Fs 2618 count for filters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Python: Remote Attach (Outside container)",
       "type": "python",
       "request": "attach",
-      "connect": { "host": "localhost", "port": 5678 },
+      "connect": { "host": "localhost", "port": 5688 },
       "pathMappings": [
         { "localRoot": "${workspaceFolder}", "remoteRoot": "." }
       ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.10-bullseye
 
 WORKDIR /app
-COPY requirements.txt requirements.txt
-RUN python3 -m pip install --upgrade pip && pip install -r requirements.txt
+COPY requirements-dev.txt requirements-dev.txt
+RUN python3 -m pip install --upgrade pip && pip install -r requirements-dev.txt
 COPY . .
 
 EXPOSE 8080

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -230,11 +230,13 @@ def get_applications(params: dict) -> Union[List[Application], None]:
     return None
 
 
-def get_assessments_stats(fund_id: str, round_id: str) -> Dict | None:
+def get_assessments_stats(
+    fund_id: str, round_id: str, search_params: dict = {}
+) -> Dict | None:
     assessments_stats_endpoint = (
         Config.ASSESSMENT_STORE_API_HOST
     ) + Config.ASSESSMENTS_STATS_ENDPOINT.format(
-        fund_id=fund_id, round_id=round_id
+        fund_id=fund_id, round_id=round_id, params=urlencode(search_params)
     )
     current_app.logger.info(f"Endpoint '{assessments_stats_endpoint}'.")
     return get_data(assessments_stats_endpoint)

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -376,7 +376,7 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
         "round_short_name": round_short_name,
     }
 
-    stats = get_assessments_stats(fund_id, round_id)
+    stats = get_assessments_stats(fund_id, round_id, search_params)
     is_active_status = is_after_today(_round.assessment_deadline)
 
     # TODO Can we get rid of get_application_overviews for fund and _round

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -86,7 +86,9 @@ class DefaultConfig:
     APPLICATION_SEARCH_ENDPOINT = CommonConfig.APPLICATION_SEARCH_ENDPOINT
 
     # Assessment store endpoints
-    ASSESSMENTS_STATS_ENDPOINT = "/assessments/get-stats/{fund_id}/{round_id}"
+    ASSESSMENTS_STATS_ENDPOINT = (
+        "/assessments/get-stats/{fund_id}/{round_id}?{params}"
+    )
     APPLICATION_OVERVIEW_ENDPOINT_FUND_ROUND_PARAMS = (
         "/application_overviews/{fund_id}/{round_id}?{params}"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,10 +345,17 @@ def mock_get_assessment_stats(request):
         )
         fund_id = params.get("fund_id", "test-fund")
         round_id = params.get("round_id", "test-round")
+        search_params = params.get("expected_search_params", None)
     else:
         mock_func = "app.assess.routes.get_assessments_stats"
         fund_id = "test-fund"
         round_id = "test-round"
+        search_params = {
+            "search_term": "",
+            "search_in": "project_name,short_id",
+            "asset_type": "ALL",
+            "status": "ALL",
+        }
 
     with (
         mock.patch(
@@ -360,7 +367,12 @@ def mock_get_assessment_stats(request):
     ):
         yield mocked_assessment_stats
 
-    mocked_assessment_stats.assert_called_once_with(fund_id, round_id)
+    if search_params:
+        mocked_assessment_stats.assert_called_once_with(
+            fund_id, round_id, search_params
+        )
+    else:
+        mocked_assessment_stats.assert_called_once_with(fund_id, round_id)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -19,12 +19,6 @@ class TestRoutes:
             "get_rounds_path": "app.assess.models.fund_summary.get_rounds",
             "fund_id": "test-fund",
             "round_id": "test-round",
-            "expected_search_params": {
-                "search_term": "",
-                "search_in": "project_name,short_id",
-                "asset_type": "ALL",
-                "status": "ALL",
-            },
         }
     )
     def test_route_landing(


### PR DESCRIPTION
Jira Ticket
https://digital.dclg.gov.uk/jira/browse/FS-2618

### Description
Implement count based on filter returns. Updated Dockerfile to comply with debugger(https://github.com/communitiesuk/funding-service-design-docker-runner/pull/33)

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Open the Assessment dashboard & select a fund/round
- Apply any filters & observe the count

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/68313e9b-fca4-4113-a757-e9b9e6ef44e5)
