### PR TITLE
BAU: Increase health-check-invocation-timeout to 20 seconds

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -47,4 +47,4 @@ applications:
     - form-uploads-test
   health-check-http-endpoint: /healthcheck
   health-check-type: http
-  health-check-invocation-timeout: 10
+  health-check-invocation-timeout: 20


### PR DESCRIPTION
### Change description

Increasing the healthchecks timeout to 20 seconds as the app on Test env has been restarting recently at random times during some e2e test runs which disrupts the tests.  

https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#health-check-invocation-timeout
https://cli.cloudfoundry.org/en-US/v6/v3-set-health-check.html



### How to test

Once this PR is merged run the e2e tests for Assessment locally and the tests should pass without any environment issues. 


### Screenshots of UI changes (if applicable)

N/A
