### PR TITLE
BAU: Update memory on assessment test

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
     - form-uploads-dev
 
 - name: funding-service-design-assessment-test
-  memory: 64M
+  memory: 128M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py


### PR DESCRIPTION
### Change description

Adding a little more memory, we're seeing seemingly random `502`s and it may be the memory causing the hiccups.

We're using around 95% idle so... maybe it's that?

```
name:              funding-service-design-assessment-test
requested state:   started
routes:            funding-service-design-assessment-test.london.cloudapps.digital, assessment.test.fundingservice.co.uk, assessment.test.gids.dev
last uploaded:     Mon 15 May 15:37:32 BST 2023
stack:             cflinuxfs3
buildpacks:
        name                                                   version   detect output   buildpack name
        https://github.com/cloudfoundry/python-buildpack.git   1.8.9     python          python

type:           web
sidecars:
instances:      1/1
memory usage:   64M
     state     since                  cpu    memory         disk         logging            details
#0   running   2023-05-15T14:38:03Z   0.1%   60.6M of 64M   689M of 1G   0/s of unlimited
```