### PR TITLE
FS-2683 - Increase memory to 256mb on Assessment frontend test

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
     - form-uploads-dev
 
 - name: funding-service-design-assessment-test
-  memory: 128M
+  memory: 256M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py


### PR DESCRIPTION
### Change description

Related to https://github.com/communitiesuk/funding-service-design-assessment/pull/247

https://digital.dclg.gov.uk/jira/browse/FS-2683

There are still a very small amount of 502s being returned since increasing to 128mb. So I'm increasing the memory further on assessment test. Frontend test has 256mb of memory as well.

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/36962596/ef3c898e-4a79-49fb-958d-ff972007e45e)



### How to test

Run e2e tests for Assessment locally or via the manual workflow in the e2e checks repo after this PR has been merged and the tests should run smoothly without any env issues. 

Also run `cf app funding-service-design-assessment-test` to check memory after this memory bump has been merged to Test env. 


### Screenshots of UI changes (if applicable)

N/A
