### PR TITLE
add showallrounds env for developer productivity

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Python: Remote Attach (Outside container)",
       "type": "python",
       "request": "attach",
-      "connect": { "host": "localhost", "port": 5686 },
+      "connect": { "host": "localhost", "port": 5689 },
       "pathMappings": [
         { "localRoot": "${workspaceFolder}", "remoteRoot": "." }
       ],

--- a/app/assess/models/fund_summary.py
+++ b/app/assess/models/fund_summary.py
@@ -5,6 +5,7 @@ import pytz
 from app.assess.data import get_assessments_stats
 from app.assess.data import get_rounds
 from app.assess.models.fund import Fund
+from config import Config
 from flask import url_for
 
 
@@ -30,8 +31,8 @@ def create_fund_summaries(fund: Fund) -> list[FundSummary]:
     """Get all the round stats in a fund."""
     summaries = []
     for round in get_rounds(fund.id):
-        # only show closed rounds in assessment
-        if not is_after_today(round.deadline):
+        # only show closed rounds in assessment unless `SHOW_ALL_ROUNDS`==True
+        if Config.SHOW_ALL_ROUNDS or (not is_after_today(round.deadline)):
             round_stats = get_assessments_stats(fund.id, round.id)
             summary = FundSummary(
                 name=round.title,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -5,6 +5,7 @@ from os import environ
 from os import getenv
 from pathlib import Path
 
+from distutils.util import strtobool
 from fsd_utils import CommonConfig
 from fsd_utils import configclass
 
@@ -40,6 +41,9 @@ class DefaultConfig:
     LOCAL_SERVICE_NAME = "local_flask"
     ASSESSMENT_HUB_ROUTE = "/assess"
     DASHBOARD_ROUTE = "/assess/assessor_tool_dashboard"
+
+    # Assessement settings
+    SHOW_ALL_ROUNDS = strtobool(getenv("SHOW_ALL_ROUNDS", "False"))
 
     """
     Security

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -26,6 +26,7 @@ class DevelopmentConfig(DefaultConfig):
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
 
     DEBUG_USER_ON = False  # Set to True to use DEBUG user
+    SHOW_ALL_ROUNDS = True  # Set to True to show all rounds
 
     DEBUG_USER_ROLE = getenv(
         "DEBUG_USER_ROLE", "LEAD_ASSESSOR" if DEBUG_USER_ON else ""


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2993

### Description
Currently, only closed rounds are shown in the Assessment dashboard
During development, we want to see all open, closed, active & inactive rounds in the assessment dashboard.
Added a variable `SHOW_ALL_ROUNDS` & set this to `true` in development config. If `True` all rounds are displayed in the Assessment dashboard.

Also changed the port number in launch json to sync with docker-runner

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
