### PR TITLE
Display multiple flags on the applications overview

### DIFF
--- a/app/assess/templates/components/application_overviews_table.html
+++ b/app/assess/templates/components/application_overviews_table.html
@@ -147,6 +147,12 @@
                   {{ overview.flags[-1].flag_type | capitalize }}
                 </span>
                 {% elif overview.flags
+                  and overview.flags[-1].flag_type == "FLAGGED" and overview.flags[-1].sections_to_flag|length > 1
+                %}
+                <span class="flagged-tag">
+                  {{ "Multiple Flags Applied" | capitalize }}
+                </span>
+                {% elif overview.flags
                   and overview.flags[-1].flag_type == "FLAGGED"
                 %}
                 <span class="flagged-tag">


### PR DESCRIPTION
[FS-2775](https://digital.dclg.gov.uk/jira/browse/FS-2775)

### Change description
When multiple flags are selected, the applications landing page status displayed Multiple Flags Applied 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Go to a application and Apply multiple flags. When going back to the assessor dashboard you will see the status as multiple flas applied 


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/84cf9122-ce32-46c5-916d-f6faf50b064c)
