### PR TITLE
FS-2643-body-content-not-inline-with-the-banner

### DIFF
--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -64,5 +64,4 @@
         </div>
     </div>
 
-
 {% endblock content %}

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -25,7 +25,6 @@
 </div>
 {% endif %}
 
-<div class="govuk-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-two-thirds flagging-container">
@@ -64,6 +63,6 @@
             </div>
         </div>
     </div>
-</div>
+
 
 {% endblock content %}

--- a/app/assess/templates/contract_downloads.html
+++ b/app/assess/templates/contract_downloads.html
@@ -10,21 +10,24 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-two-thirds">
 
-        <h2 class="govuk-heading-l govuk-!-margin-top-4">Export application data</h2>
-        <ul class="govuk-list">
-            <li><a class="govuk-link" href="{{ application_answers[1] }}">{{ application_answers[0] }}</a></li>
-        </ul>
-        <h3 class="govuk-heading-l govuk-!-margin-top-4">Supporting evidence</h3>
-        <ul class="govuk-list">
-            {% if supporting_evidence | length > 0 %}
-                {% for document in supporting_evidence %}
-                <li><a class="govuk-link" href="{{ document[1] }}">{{ document[0] }}</a></li>
-                {% endfor %}
-            {% else %}
-                There are no supporting evidence documents available.
-            {% endif %}
-        </ul>
+            <h2 class="govuk-heading-l govuk-!-margin-top-4">Export application data</h2>
+            <ul class="govuk-list">
+                <li><a class="govuk-link" href="{{ application_answers[1] }}">{{ application_answers[0] }}</a></li>
+            </ul>
+            <h3 class="govuk-heading-l govuk-!-margin-top-4">Supporting evidence</h3>
+            <ul class="govuk-list">
+                {% if supporting_evidence | length > 0 %}
+                    {% for document in supporting_evidence %}
+                    <li><a class="govuk-link" href="{{ document[1] }}">{{ document[0] }}</a></li>
+                    {% endfor %}
+                {% else %}
+                    There are no supporting evidence documents available.
+                {% endif %}
+            </ul>
+
+        </div>
     </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
### Ticket
https://digital.dclg.gov.uk/jira/secure/RapidBoard.jspa?rapidView=110&view=planning&selectedIssue=FS-2643&quickFilter=786&issueLimit=100


### Description
This PR fixes the alignment of the body with the banner for the following pages
- continue assessment 
- export application data 

### How to test
NA


### Screenshots of UI changes 

**Continue assessment page**
![Screenshot 2023-06-20 at 18 25 05](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/a3a1633b-dde8-497b-86fc-70738e546884)


**Export application data page**
![Screenshot 2023-06-20 at 18 21 19](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/b9b364fb-1775-4cef-a865-7c3cf4dac111)

