### PR TITLE
BAU: Add safe-guard for mock assessments

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -549,7 +549,8 @@ def list_files_in_folder(prefix):
         Bucket=Config.AWS_BUCKET_NAME, Prefix=prefix
     )
     keys = []
-    for obj in response.get("Contents") or []:
+    current_app.logger.info(f"Response: {response}")
+    for obj in response['Contents']:
         # we cut off the application id.
         _, key = obj["Key"].split("/", 1)
         keys.append(key)

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -550,7 +550,7 @@ def list_files_in_folder(prefix):
     )
     keys = []
     current_app.logger.info(f"Response: {response}")
-    for obj in response['Contents']:
+    for obj in response["Contents"]:
         # we cut off the application id.
         _, key = obj["Key"].split("/", 1)
         keys.append(key)

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -549,7 +549,7 @@ def list_files_in_folder(prefix):
         Bucket=Config.AWS_BUCKET_NAME, Prefix=prefix
     )
     keys = []
-    for obj in response["Contents"]:
+    for obj in response.get("Contents") or []:
         # we cut off the application id.
         _, key = obj["Key"].split("/", 1)
         keys.append(key)


### PR DESCRIPTION
We've seeded some mock assessments for NSTF, these don't have files attached as they haven't went through the full end-to-end journey, so when we are attempting to retrieve the files from AWS, we're getting an error since the keys don't exist.

This PR adds a small safeguard for that scenario, so we don't explode the page when this happens.