### PR TITLE
BAU: Fix bug with optional files

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -549,8 +549,7 @@ def list_files_in_folder(prefix):
         Bucket=Config.AWS_BUCKET_NAME, Prefix=prefix
     )
     keys = []
-    current_app.logger.info(f"Response: {response}")
-    for obj in response["Contents"]:
+    for obj in response.get("Contents") or []:
         # we cut off the application id.
         _, key = obj["Key"].split("/", 1)
         keys.append(key)


### PR DESCRIPTION
When a file doesn't exist, the `Contents` isn't in the dict, this handles it better and returns an empty list.