### PR TITLE
FS-3020 Remove references to cof

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -98,7 +98,6 @@ def display_sub_criteria(
     if not assessor_task_list_metadata:
         abort(404)
 
-    # maybe there's a better way to do this?..
     fund = get_fund(assessor_task_list_metadata["fund_id"])
     flag = get_latest_flag(application_id)
 
@@ -166,7 +165,6 @@ def score(
     if not assessor_task_list_metadata:
         abort(404)
 
-    # maybe there's a better way to do this?..
     fund = get_fund(assessor_task_list_metadata["fund_id"])
     flag = get_latest_flag(application_id)
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -93,7 +93,13 @@ def display_sub_criteria(
             )
         )
 
-    fund = get_fund(Config.COF_FUND_ID)
+    assessor_task_list_metadata = get_assessor_task_list_state(application_id)
+
+    if not assessor_task_list_metadata:
+        abort(404)
+
+    # maybe there's a better way to do this?..
+    fund = get_fund(assessor_task_list_metadata["fund_id"])
     flag = get_latest_flag(application_id)
 
     comment_response = get_comments(
@@ -154,7 +160,14 @@ def score(
 
     if not sub_criteria.is_scored:
         abort(404)
-    fund = get_fund(Config.COF_FUND_ID)
+
+    assessor_task_list_metadata = get_assessor_task_list_state(application_id)
+
+    if not assessor_task_list_metadata:
+        abort(404)
+
+    # maybe there's a better way to do this?..
+    fund = get_fund(assessor_task_list_metadata["fund_id"])
     flag = get_latest_flag(application_id)
 
     comment_response = get_comments(
@@ -203,7 +216,7 @@ def score(
         else None
     )
     # TODO make COF_score_list extendable to other funds
-    COF_score_list = [
+    scoring_list = [
         (5, "Strong"),
         (4, "Good"),
         (3, "Satisfactory"),
@@ -215,7 +228,7 @@ def score(
         application_id=application_id,
         score_list=scores_with_account_details or None,
         latest_score=latest_score,
-        COF_score_list=COF_score_list,
+        scoring_list=scoring_list,
         score_form=score_form,
         rescore_form=rescore_form,
         is_rescore=is_rescore,

--- a/app/assess/templates/macros/scores_justification.html
+++ b/app/assess/templates/macros/scores_justification.html
@@ -2,7 +2,7 @@
 {% from "macros/justification.html" import justification %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, COF_score_list) %}
+{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, scoring_list) %}
 
 <div class="govuk-grid-column-full s26-scoring">
     {% if latest_score %}
@@ -70,7 +70,7 @@
                 the&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="https://mhclg.sharepoint.com/:w:/s/CommunityOwnershipFund/Ecv3iM7U0AtKtyHnzRrQ9dsB0HdMPvHWqAoGn1WrWM7EMA?e=6QpdUT">assessment
                     criteria</a>.</p>
             <p class="govuk-body">You can rescore at any point.</p>
-            {{ scores(score_form, COF_score_list) }}
+            {{ scores(score_form, scoring_list) }}
             {{ justification(score_form) }}
         </div>
         {% if latest_score %}

--- a/app/assess/templates/score.html
+++ b/app/assess/templates/score.html
@@ -59,7 +59,7 @@ Score - {{ sub_criteria.name }} - {{ sub_criteria.project_name }}
         </div>
         <div class="theme govuk-grid-column-two-thirds">
             {{ scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id,
-            sub_criteria.id, COF_score_list) }}
+            sub_criteria.id, scoring_list) }}
             {{ comment_summary(comments,sub_criteria.themes) }}
         </div>
     </div>

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -24,7 +24,7 @@ class DevelopmentConfig(DefaultConfig):
     SSO_LOGIN_URL = AUTHENTICATOR_HOST + "/sso/login"
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
 
-    DEBUG_USER_ON = False  # Set to True to use DEBUG user
+    DEBUG_USER_ON = True  # Set to True to use DEBUG user
     SHOW_ALL_ROUNDS = True  # Set to True to show all rounds
 
     DEBUG_USER_ROLE = getenv(

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -24,7 +24,7 @@ class DevelopmentConfig(DefaultConfig):
     SSO_LOGIN_URL = AUTHENTICATOR_HOST + "/sso/login"
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
 
-    DEBUG_USER_ON = True  # Set to True to use DEBUG user
+    DEBUG_USER_ON = False  # Set to True to use DEBUG user
     SHOW_ALL_ROUNDS = True  # Set to True to show all rounds
 
     DEBUG_USER_ROLE = getenv(

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -172,6 +172,7 @@ class TestAuthorisation:
         mock_get_latest_flag,
         mock_get_comments,
         mock_get_sub_criteria_theme,
+        mock_get_assessor_tasklist_state,
         claims,
         ability_to_score,
     ):
@@ -239,6 +240,7 @@ class TestAuthorisation:
         mock_get_latest_flag,
         mock_get_comments,
         mock_get_sub_criteria_theme,
+        mock_get_assessor_tasklist_state,
     ):
         """
         GIVEN authorized users

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -377,6 +377,7 @@ class TestRoutes:
         mock_get_latest_flag,
         mock_get_scores,
         mock_get_bulk_accounts,
+        mock_get_assessor_tasklist_state,
     ):
 
         application_id = request.node.get_closest_marker(
@@ -852,6 +853,7 @@ class TestRoutes:
         mock_get_latest_flag,
         mock_get_comments,
         mock_get_sub_criteria_theme,
+        mock_get_assessor_tasklist_state,
     ):
         # Mocking fsd-user-token cookie
         token = create_valid_token(test_commenter_claims)


### PR DESCRIPTION
[FS-3020 Refactor explicit references to COF in assessment code to general fund](https://digital.dclg.gov.uk/jira/browse/FS-3020)


### Change description
Removed references to COF and Fixed issue with old community fund displaying on the sub criteria page

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Got to the sub criteria page for night shelter and make sure that it banner says Night Shelter


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/c1d290e4-79f2-4b81-bec7-b96c3a8e5463)
