### PR TITLE
FS-3016-styling-fix-for-free-text-presentation-type

### DIFF
--- a/app/assess/templates/macros/theme/question_above_answer_html.jinja2
+++ b/app/assess/templates/macros/theme/question_above_answer_html.jinja2
@@ -1,6 +1,6 @@
 {% macro question_above_answer_html(meta) %}
 
     <h2 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h2>
-   {{ meta.answer | safe }}
+    <span class="govuk-body"> {{ meta.answer | safe }} </span>
 
 {% endmacro %}

--- a/app/assess/templates/macros/theme/question_above_href_answer_list.jinja2
+++ b/app/assess/templates/macros/theme/question_above_href_answer_list.jinja2
@@ -12,7 +12,7 @@
         </h3>
     {% endfor %}
     {% if not meta.key_to_url_dict %}
-        Not provided.
+        <p class="govuk-body">Not provided.</p>
     {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
This small PR fixes the styling for presentation type "free_text"

![Screenshot 2023-06-21 at 18 27 50](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/99016539-4c55-4070-8273-205643c77bba)
