### PR TITLE
Fs 2664 display flag history

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -362,7 +362,8 @@ def get_flags(application_id: str) -> Optional[Flag]:
     flags = get_data(
         Config.ASSESSMENT_FLAGS_ENDPOINT.format(application_id=application_id)
     )
-    # TODO: Remove mock data used for flag history development
+    # TODO: Remove mock data used for flag history development and
+    # Refactor below code after schema changes made for multiple flags
     test_application_id = "81480ade-0487-4097-8dec-bba3116ee7f3"
     if application_id == test_application_id:
         flags = [

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -363,11 +363,12 @@ def get_flags(application_id: str) -> Optional[Flag]:
         Config.ASSESSMENT_FLAGS_ENDPOINT.format(application_id=application_id)
     )
     # TODO: Remove mock data used for flag history development
-    if application_id == "81480ade-0487-4097-8dec-bba3116ee7f3":
+    test_application_id = "81480ade-0487-4097-8dec-bba3116ee7f3"
+    if application_id == test_application_id:
         flags = [
             {
                 "id": "b0ac84e5-bb97-4851-9ba3-4d1101030e9f",
-                "application_id": "81480ade-0487-4097-8dec-bba3116ee7f3",
+                "application_id": test_application_id,
                 "status": "RAISED",
                 "allocation": "TEAM_1",
                 "sections_to_flag": ["benefits", "engagement"],
@@ -386,7 +387,7 @@ def get_flags(application_id: str) -> Optional[Flag]:
             },
             {
                 "id": "f60f816e-0497-47a7-9211-1515f7939fbe",
-                "application_id": "81480ade-0487-4097-8dec-bba3116ee7f3",
+                "application_id": test_application_id,
                 "status": "RESOLVED",
                 "allocation": "TEAM_2",
                 "sections_to_flag": ["financial_and_risk_forecasts"],

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -9,6 +9,7 @@ from app.assess.models.application import Application
 from app.assess.models.banner import Banner
 from app.assess.models.comment import Comment
 from app.assess.models.flag import Flag
+from app.assess.models.flag import Flags
 from app.assess.models.fund import Fund
 from app.assess.models.round import Round
 from app.assess.models.score import Score
@@ -353,6 +354,72 @@ def get_flag(flag_id: str) -> Optional[Flag]:
         return Flag.from_dict(flag)
     else:
         msg = f"flag for id: '{flag_id}' not found."
+        current_app.logger.warn(msg)
+        return None
+
+
+def get_flags(application_id: str) -> Optional[Flag]:
+    flags = get_data(
+        Config.ASSESSMENT_FLAGS_ENDPOINT.format(application_id=application_id)
+    )
+    # TODO: Remove mock data used for flag history development
+    if application_id == "81480ade-0487-4097-8dec-bba3116ee7f3":
+        flags = [
+            {
+                "id": "b0ac84e5-bb97-4851-9ba3-4d1101030e9f",
+                "application_id": "81480ade-0487-4097-8dec-bba3116ee7f3",
+                "status": "RAISED",
+                "allocation": "TEAM_1",
+                "sections_to_flag": ["benefits", "engagement"],
+                "updates": [
+                    {
+                        "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
+                        "user_id": "00000000-0000-0000-0000-000000000000",
+                        "date_created": "2023-06-15T13:26:36.695671",
+                        "justification": (
+                            "Not enough info in benefits or engagement"
+                        ),
+                        "status": "RAISED",
+                        "allocation": "TEAM_1",
+                    }
+                ],
+            },
+            {
+                "id": "f60f816e-0497-47a7-9211-1515f7939fbe",
+                "application_id": "81480ade-0487-4097-8dec-bba3116ee7f3",
+                "status": "RESOLVED",
+                "allocation": "TEAM_2",
+                "sections_to_flag": ["financial_and_risk_forecasts"],
+                "updates": [
+                    {
+                        "id": "70b723be-1244-43a9-a613-69ac75188dab",
+                        "user_id": "00000000-0000-0000-0000-000000000000",
+                        "date_created": "2023-05-15T09:33:36.695671",
+                        "justification": (
+                            "Not happy with risk mitigation strategies"
+                        ),
+                        "status": "RAISED",
+                        "allocation": "TEAM_2",
+                    },
+                    {
+                        "id": "b5d01d22-cc5c-4191-a468-219f00ff9af6",
+                        "user_id": "00000000-0000-0000-0000-000000000000",
+                        "date_created": "2023-05-17T11:54:36.695671",
+                        "justification": (
+                            "Clarity given on risk mitigation, ok to proceed"
+                        ),
+                        "status": "RESOLVED",
+                        "allocation": "TEAM_2",
+                    },
+                ],
+            },
+        ]
+
+    if flags:
+        flags_list = Flags.from_dict(flags)
+        return flags_list
+    else:
+        msg = f"List flag for application: '{application_id}' not found."
         current_app.logger.warn(msg)
         return None
 

--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -47,6 +47,7 @@ def resolve_application(
     page_to_render,
     state=None,
     reason_to_flag="",
+    allocated_team="",
 ):
     """This function is used to resolve an application
       by submitting a flag, justification, and section for the application.
@@ -93,6 +94,7 @@ def resolve_application(
         state=state,
         sections_to_flag=section,
         reason_to_flag=reason_to_flag,
+        allocated_team=allocated_team,
     )
 
 

--- a/app/assess/models/flag.py
+++ b/app/assess/models/flag.py
@@ -41,6 +41,7 @@ class Flag:
         )
 
 
+# TODO: Refactor below class after assessment-store schema changes for multiple flags
 @dataclass()
 class Flags:
     id: str
@@ -54,6 +55,9 @@ class Flags:
     allocation: str
 
     def __post_init__(self):
+        # TODO: Uncomment below code after Enum types are upodated with ESCALATED & RAISED
+        # in assessment-store and in above class `FlagType`
+
         # if self.flag_type:
         #     self.flag_type = FlagType[self.flag_type]
 

--- a/app/assess/models/flag.py
+++ b/app/assess/models/flag.py
@@ -39,3 +39,39 @@ class Flag:
                 if k in inspect.signature(cls).parameters
             }
         )
+
+
+@dataclass()
+class Flags:
+    id: str
+    # justification: str
+    sections_to_flag: str
+    status: FlagType | str
+    application_id: str
+    # user_id: str
+    updates: list
+    # is_qa_complete: bool = False
+    allocation: str
+
+    def __post_init__(self):
+        # if self.flag_type:
+        #     self.flag_type = FlagType[self.flag_type]
+
+        for item in self.updates:
+            item["date_created"] = datetime.fromisoformat(
+                item["date_created"]
+            ).strftime("%Y-%m-%d %X")
+
+    @classmethod
+    def from_dict(cls, lst: list):
+        all_flags = [
+            cls(
+                **{
+                    k: v
+                    for k, v in d.items()
+                    if k in inspect.signature(cls).parameters
+                }
+            )
+            for d in lst
+        ]
+        return all_flags

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -604,7 +604,12 @@ def resolve_flag(application_id):
 @login_required(roles_required=["LEAD_ASSESSOR"])
 def continue_assessment(application_id):
     form = ContinueApplicationForm()
-    # TODO: Resolve flag for multiple sections flag to be implemented
+    flag_id = request.args.get("flag_id")
+
+    if not flag_id:
+        current_app.logger.error("No flag id found in query params")
+        abort(404)
+    flag_data = get_flag(flag_id)
     return resolve_application(
         form=form,
         application_id=application_id,
@@ -613,6 +618,7 @@ def continue_assessment(application_id):
         justification=form.reason.data,
         section=["NA"],
         page_to_render="continue_assessment.html",
+        reason_to_flag=flag_data.justification,
     )
 
 

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -482,18 +482,23 @@ def application(application_id):
 
     state = AssessorTaskList.from_json(assessor_task_list_metadata)
     flag = get_latest_flag(application_id)
-    flags_list = get_flags(application_id)
-    user_id_list = []
-    for flag_data in flags_list:
-        for flag_item in flag_data.updates:
-            if flag_item["user_id"] not in user_id_list:
-                user_id_list.append(flag_item["user_id"])
-
     if flag:
         accounts = get_bulk_accounts_dict([flag.user_id])
 
-    if flags_list:
-        accounts_list = get_bulk_accounts_dict(user_id_list)
+    # TODO: Remove mock data used for flag history development
+    if application_id == "81480ade-0487-4097-8dec-bba3116ee7f3":
+        flags_list = get_flags(application_id)
+        user_id_list = []
+        for flag_data in flags_list:
+            for flag_item in flag_data.updates:
+                if flag_item["user_id"] not in user_id_list:
+                    user_id_list.append(flag_item["user_id"])
+        if flags_list:
+            accounts_list = get_bulk_accounts_dict(user_id_list)
+
+    else:
+        flags_list = []
+        accounts_list = []
 
     sub_criteria_status_completed = all_status_completed(state)
     form = AssessmentCompleteForm()

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -482,8 +482,18 @@ def application(application_id):
 
     state = AssessorTaskList.from_json(assessor_task_list_metadata)
     flag = get_latest_flag(application_id)
+    flags_list = get_flags(application_id)
+    user_id_list = []
+    for flag_data in flags_list:
+        for flag_item in flag_data.updates:
+            if flag_item["user_id"] not in user_id_list:
+                user_id_list.append(flag_item["user_id"])
+
     if flag:
         accounts = get_bulk_accounts_dict([flag.user_id])
+
+    if flags_list:
+        accounts_list = get_bulk_accounts_dict(user_id_list)
 
     sub_criteria_status_completed = all_status_completed(state)
     form = AssessmentCompleteForm()
@@ -509,6 +519,8 @@ def application(application_id):
         state=state,
         application_id=application_id,
         flag=flag,
+        accounts_list=accounts_list,
+        flags_list=flags_list,
         current_user_role=g.user.highest_role,
         fund_short_name=fund.short_name,
         round_short_name=round.short_name,

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -485,8 +485,9 @@ def application(application_id):
     if flag:
         accounts = get_bulk_accounts_dict([flag.user_id])
 
-    # TODO: Remove mock data used for flag history development
-    if application_id == "81480ade-0487-4097-8dec-bba3116ee7f3":
+    # TODO: Remove mock data used for flag history development and
+    # Refactor below code after schema changes made for multiple flags
+    try:
         flags_list = get_flags(application_id)
         user_id_list = []
         for flag_data in flags_list:
@@ -495,8 +496,7 @@ def application(application_id):
                     user_id_list.append(flag_item["user_id"])
         if flags_list:
             accounts_list = get_bulk_accounts_dict(user_id_list)
-
-    else:
+    except Exception:
         flags_list = []
         accounts_list = []
 

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -42,7 +42,7 @@
 {% block content %}
 
 <div>
-    {{ flag_tabs(state, flags_list, accounts_list) }}
+    {{ flag_tabs(state, application_id, flags_list, accounts_list) }}
 </div>
 
 <div>

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
+{% from "macros/flag_history.html" import flag_tabs %}
 {% from 'macros/section_element.html' import section_element -%}
 {% from 'macros/criteria_element.html' import criteria_element -%}
 {% from "macros/banner_summary.html" import banner_summary %}
@@ -40,19 +41,25 @@
 
 {% block content %}
 
-{% if flag and current_user_role in ["ASSESSOR", "LEAD_ASSESSOR"] and flag.is_qa_complete %}
-    {{ qa_complete_flag(flag, flag_user_info, form.csrf_token, application_id, current_user_role) }}
-{% endif %}
+<div>
+    {{ flag_tabs(state, flags_list, accounts_list) }}
+</div>
 
-{% if flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and flag.flag_type.name == "FLAGGED" %}
-    {{ assessment_flagged(state, flag, flag_user_info, application_id, current_user_role) }}
-{% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and display_status == "STOPPED" %}
-    {{ assessment_stopped(flag, flag_user_info, application_id, current_user_role) }}
-{% endif %}
+<div>
+    {% if flag and current_user_role in ["ASSESSOR", "LEAD_ASSESSOR"] and flag.is_qa_complete %}
+        {{ qa_complete_flag(flag, flag_user_info, form.csrf_token, application_id, current_user_role) }}
+    {% endif %}
 
-{% if sub_criteria_status_completed and current_user_role != "COMMENTER" and not flag.is_qa_complete %}
-{{ assessment_complete(state, flag, form.csrf_token, application_id, current_user_role )}}
-{% endif %}
+    {% if flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and flag.flag_type.name == "FLAGGED" %}
+        {{ assessment_flagged(state, flag, flag_user_info, application_id, current_user_role) }}
+    {% elif flag and current_user_role in ("ASSESSOR", "LEAD_ASSESSOR") and display_status == "STOPPED" %}
+        {{ assessment_stopped(flag, flag_user_info, application_id, current_user_role) }}
+    {% endif %}
+
+    {% if sub_criteria_status_completed and current_user_role != "COMMENTER" and not flag.is_qa_complete %}
+    {{ assessment_complete(state, flag, form.csrf_token, application_id, current_user_role )}}
+    {% endif %}
+</div>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/assess/templates/continue_assessment.html
+++ b/app/assess/templates/continue_assessment.html
@@ -34,6 +34,11 @@
 
                     <p class="govuk-body">This will remove the flag and allow assessment to continue.</p>
 
+                    <div class="govuk-inset-text">
+                        <p><strong>Stop assessment reason</strong><br>{{ reason_to_flag }}</p>
+                        <p><strong>Flag allocation</strong><br>{{ 'Flagged for ' + allocated_team if allocated_team else 'N/A' }}</p>
+                    </div>
+
                     <div class="govuk-form-group">
 
                         {{ govukTextarea({

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -132,36 +132,38 @@
                             })
                         }}
 
-                        {# Get list of sub-sections from Scored section #}
-                        {% call govukFieldset({
-                                'legend': {
-                                    'html': "<h1 class=\"govuk-fieldset__heading govuk-!-margin-top-5\">Scored</h1>",
-                                    'classes': 'govuk-fieldset__legend--s'
-                                    }
-                                })
-                        %}
-                        {% for section in state.criterias %}
-                            {% set items = [] %}
-                            {% for sub_section in section.sub_criterias %}
-                                {% set addItem = items.append({'value': sub_section["id"],
-                                                            'text': sub_section["name"]}) %}
-                            {% endfor %}
-                            {{ govukCheckboxes({
-                                'idPrefix': section["name"],
-                                'name': form.section.id,
-                                'fieldset': {
+                        <div class="govuk-form-group">
+                            {# Get list of sub-sections from Scored section #}
+                            {% call govukFieldset({
                                     'legend': {
-                                    'html': "<h1 class=\"govuk-fieldset__heading\">{}</h1>".format(section["name"]),
-                                    'classes': 'govuk-fieldset__legend--s'
-                                    }
-                                },
-                                'attributes': {'data-qa': 'select_scored_section_to_flag'},
-                                'items': items,
-                                'classes': 'govuk-checkboxes--small'
-                                })
-                            }}
-                        {% endfor %}
-                        {% endcall %}
+                                        'html': "<h1 class=\"govuk-fieldset__heading\">Scored</h1>",
+                                        'classes': 'govuk-fieldset__legend--s'
+                                        }
+                                    })
+                            %}
+                            {% for section in state.criterias %}
+                                {% set items = [] %}
+                                {% for sub_section in section.sub_criterias %}
+                                    {% set addItem = items.append({'value': sub_section["id"],
+                                                                'text': sub_section["name"]}) %}
+                                {% endfor %}
+                                {{ govukCheckboxes({
+                                    'idPrefix': section["name"],
+                                    'name': form.section.id,
+                                    'fieldset': {
+                                        'legend': {
+                                        'html': "<h1 class=\"govuk-fieldset__heading\">{}</h1>".format(section["name"]),
+                                        'classes': 'govuk-fieldset__legend--s'
+                                        }
+                                    },
+                                    'attributes': {'data-qa': 'select_scored_section_to_flag'},
+                                    'items': items,
+                                    'classes': 'govuk-checkboxes--small'
+                                    })
+                                }}
+                            {% endfor %}
+                            {% endcall %}
+                        </div>
                     </div>
 
                     <div class="govuk-button-group">

--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -1,22 +1,19 @@
+{% from "macros/flag_history.html" import display_flagged_sections %}
+
 {% macro assessment_flagged(state, flag, user_info, application_id, current_user_role) %}
     <div class="assessment-alert assessment-alert--flagged" role="alert">
         <h1 class="assessment-alert__heading govuk-heading-l">
             {{ flag.flag_type.name | title }}
         </h1>
-        <h2 class="govuk-heading-m">Reason</h2>
-        <p class="govuk-body">{{ flag.justification }}</p>
-        <h2 class="govuk-heading-m">Section(s) flagged</h2>
-        {% for sub_section_id in flag.sections_to_flag %}
-            {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
-            {% if sub_section_data %}
-                <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
-            {% else %}
-                <p class="govuk-body">{{ sub_section_id }}</p>
-            {% endif %}
-        {% endfor %}
+        <h2>Reason</h2>
+        <p>{{ flag.justification }}</p>
+        <h2>Section(s) flagged</h2>
+        {{ display_flagged_sections(state, application_id, flag.sections_to_flag) }}
+        {# TODO: Notification is hardcoded. Change it once notification is implemented #}
+        <h2>Notification sent</h2>
+        <p>No</p><br>
         <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | utc_to_bst }}</p>
-        {# TODO: Resolve flag will be removed #}
         {% if current_user_role == "LEAD_ASSESSOR" %}
             <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.resolve_flag',application_id=application_id)}}?flag_id={{ flag.id }}">Resolve flag</a></p>
         {% endif %}
@@ -31,7 +28,7 @@
         <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | utc_to_bst }}</p>
         {% if current_user_role == "LEAD_ASSESSOR" %}
-            <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.continue_assessment',application_id=application_id)}}">Remove flag and continue assessment</a></p>
+            <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.continue_assessment',application_id=application_id)}}?flag_id={{ flag.id }}">Remove flag and continue assessment</a></p>
         {% endif %}
     </div>
 {% endmacro %}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -16,22 +16,28 @@
     {% set items = [] %}
     {% for data in flag_data.updates %}
         {% set FlagDetails %}
-            {% if data['status']!='RESOLVED' %}
+            {% if data['status']=='RAISED' %}
                 <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
                 <p><strong>Section(s) flagged</strong><br></p>
                 {{ display_flagged_sections(state, application_id, flag_data['sections_to_flag']) }}
-                <p><strong>Flag allocation</strong><br> <span class="flagged-tag">Flagged for {{ flag_data.allocation }}</span></p>
+                <p><strong>Flag allocation</strong><br> <span class="flagged-tag">Flagged for {{ data['allocation'] }}</span></p>
                 <p><strong>Notification sent</strong><br>No</p>
             {% else %}
-                <p><strong>Resolve flag action</strong><br>Query resolved</p>
+                {% if data['status']=='STOPPED' %}
+                    <p><strong>Resolve flag action</strong><br>Stop assessment</p>
+                {% elif data['status']=='ESCALATED' %}
+                    <p><strong>Resolve flag action</strong><br>Flag escalated to {{ data['allocation'] }}</p>
+                {% elif data['status']=='RESOLVED' %}
+                    <p><strong>Resolve flag action</strong><br>Query resolved</p>
+                {% endif %}
                 <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
             {% endif %}
 
         {% endset %}
 
         {% set username_date = '('+ accounts_list[data['user_id']]['full_name'] + ')<br>'+ data['date_created'] | utc_to_bst %}
-        {% set CreatedBy = username_date if data['status']!='RESOLVED' else 'N/A' %}
-        {% set ResolvedBy = username_date if data['status']=='RESOLVED' else 'N/A' %}
+        {% set CreatedBy = username_date if data['status']=='RAISED' else 'N/A' %}
+        {% set ResolvedBy = username_date if data['status']!='RAISED' else 'N/A' %}
 
         {% set addItem = items.append([{'html': CreatedBy},
                                         {'text': FlagDetails},

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -1,5 +1,4 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
-{%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
 {%- from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs -%}
 
 {% macro flag_table(state, application_id, flag_data, accounts_list) %}
@@ -65,8 +64,13 @@
         }) }}
     {% endset %}
 
-    {{ govukDetails({
-        'summaryText': "Flag history",
-        'html': TabsData
-    }) }}
+    <details class="govuk-details" data-module="govuk-details" open="">
+        <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+            Flag history
+        </span>
+        </summary><br><br>
+        {{ TabsData }}
+    </details>
+
 {% endmacro %}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -1,6 +1,17 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 {%- from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs -%}
 
+{% macro display_flagged_sections(state, application_id, sections_to_flag) %}
+    {% for sub_section_id in sections_to_flag %}
+        {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
+        {% if sub_section_data %}
+            <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab) </p>
+        {% else %}
+            <p>{{ sub_section_id }}</p>
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
 {% macro flag_table(state, application_id, flag_data, accounts_list) %}
     {% set items = [] %}
     {% for data in flag_data.updates %}
@@ -8,14 +19,7 @@
             {% if data['status']!='RESOLVED' %}
                 <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
                 <p><strong>Section(s) flagged</strong><br></p>
-                {% for sub_section_id in flag_data['sections_to_flag'] %}
-                    {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
-                    {% if sub_section_data %}
-                        <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
-                    {% else %}
-                        <p>{{ sub_section_id }}</p>
-                    {% endif %}
-                {% endfor %}
+                {{ display_flagged_sections(state, application_id, flag_data['sections_to_flag']) }}
                 <p><strong>Flag allocation</strong><br> <span class="flagged-tag">Flagged for {{ flag_data.allocation }}</span></p>
                 <p><strong>Notification sent</strong><br>No</p>
             {% else %}
@@ -32,7 +36,7 @@
         {% set addItem = items.append([{'html': CreatedBy},
                                         {'text': FlagDetails},
                                         {'html': ResolvedBy},
-                                        {'text': data['status']}]) %}
+                                        {'text': data['status'] | capitalize}]) %}
     {% endfor %}
 
     <h2 class="govuk-heading-l">Flagged for {{ flag_data.allocation }}</h2>

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -1,0 +1,67 @@
+{%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
+{%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
+{%- from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs -%}
+
+{% macro flag_table(state, flag_data, accounts_list) %}
+    {% set items = [] %}
+    {% for data in flag_data.updates %}
+        {% set FlagDetails %}
+            <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
+            <p><strong>Section(s) flagged</strong><br></p>
+            {% for sub_section_id in flag_data['sections_to_flag'] %}
+                {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
+                {% if sub_section_data %}
+                    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
+                {% else %}
+                    <p>{{ sub_section_id }}</p>
+                {% endif %}
+            {% endfor %}
+            <p><strong>Flag allocation</strong><br>Flagged for {{ flag_data.allocation }}</p>
+            <p><strong>Notification sent</strong><br>No</p>
+
+        {% endset %}
+
+        {% set username_date = '('+ accounts_list[data['user_id']]['full_name'] + ')<br>'+ data['date_created'] | utc_to_bst %}
+        {% set CreatedBy = username_date if data['status']!='RESOLVED' else 'N/A' %}
+        {% set ResolvedBy = username_date if data['status']=='RESOLVED' else 'N/A' %}
+
+        {% set addItem = items.append([{'html': CreatedBy},
+                                        {'text': FlagDetails},
+                                        {'html': ResolvedBy},
+                                        {'text': data['status']}]) %}
+    {% endfor %}
+
+    <h2 class="govuk-heading-l">Flagged for {{ flag_data.allocation }}</h2>
+    {{ govukTable({
+    'head': [
+        {'text': "Created by"},
+        {'text': "Flag details"},
+        {'text': "Resolved by"},
+        {'text': "Flag status"}
+    ],
+    'rows': items
+    })}}
+{% endmacro %}
+
+{% macro flag_tabs(state, flags_list, accounts_list) %}
+    {% set TabsData %}
+        {% set items = [] %}
+        {% for flag_item in flags_list %}
+            {% set addItem = items.append({
+            'label': "Flagged for " + flag_item.allocation,
+            'id': "tab-" + flag_item.allocation,
+            'panel': {
+                'html': flag_table(state, flag_item, accounts_list)}
+            })%}
+        {% endfor %}
+
+        {{ govukTabs({
+        'items': items
+        }) }}
+    {% endset %}
+
+    {{ govukDetails({
+        'summaryText': "Flag history",
+        'html': TabsData
+    }) }}
+{% endmacro %}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -2,22 +2,27 @@
 {%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
 {%- from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs -%}
 
-{% macro flag_table(state, flag_data, accounts_list) %}
+{% macro flag_table(state, application_id, flag_data, accounts_list) %}
     {% set items = [] %}
     {% for data in flag_data.updates %}
         {% set FlagDetails %}
-            <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
-            <p><strong>Section(s) flagged</strong><br></p>
-            {% for sub_section_id in flag_data['sections_to_flag'] %}
-                {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
-                {% if sub_section_data %}
-                    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
-                {% else %}
-                    <p>{{ sub_section_id }}</p>
-                {% endif %}
-            {% endfor %}
-            <p><strong>Flag allocation</strong><br>Flagged for {{ flag_data.allocation }}</p>
-            <p><strong>Notification sent</strong><br>No</p>
+            {% if data['status']!='RESOLVED' %}
+                <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
+                <p><strong>Section(s) flagged</strong><br></p>
+                {% for sub_section_id in flag_data['sections_to_flag'] %}
+                    {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
+                    {% if sub_section_data %}
+                        <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
+                    {% else %}
+                        <p>{{ sub_section_id }}</p>
+                    {% endif %}
+                {% endfor %}
+                <p><strong>Flag allocation</strong><br> <span class="flagged-tag">Flagged for {{ flag_data.allocation }}</span></p>
+                <p><strong>Notification sent</strong><br>No</p>
+            {% else %}
+                <p><strong>Resolve flag action</strong><br>Query resolved</p>
+                <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
+            {% endif %}
 
         {% endset %}
 
@@ -43,7 +48,7 @@
     })}}
 {% endmacro %}
 
-{% macro flag_tabs(state, flags_list, accounts_list) %}
+{% macro flag_tabs(state, application_id, flags_list, accounts_list) %}
     {% set TabsData %}
         {% set items = [] %}
         {% for flag_item in flags_list %}
@@ -51,7 +56,7 @@
             'label': "Flagged for " + flag_item.allocation,
             'id': "tab-" + flag_item.allocation,
             'panel': {
-                'html': flag_table(state, flag_item, accounts_list)}
+                'html': flag_table(state, application_id, flag_item, accounts_list)}
             })%}
         {% endfor %}
 

--- a/app/assess/templates/resolve_flag.html
+++ b/app/assess/templates/resolve_flag.html
@@ -2,6 +2,7 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/fieldset/macro.html" import govukFieldset -%}
 {%- from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
+{% from "macros/flag_history.html" import display_flagged_sections %}
 {% from "macros/banner_summary.html" import banner_summary %}
 {% set pageHeading = "Resolve flag" %}
 
@@ -54,14 +55,10 @@
           <h3>Flag details</h3>
           <p><strong>Reason</strong><br>{{ reason_to_flag }}</p>
           <p><strong>Section(s) to flag</strong><br></p>
-          {% for sub_section_id in sections_to_flag %}
-              {% set sub_section_data = state.get_section_from_sub_criteria_id(sub_section_id) %}
-              {% if sub_section_data %}
-                  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.display_sub_criteria',application_id=application_id ,sub_criteria_id=sub_section_id) }}" target="_blank">{{ sub_section_data["sub_section_name"] }}</a> ({{ sub_section_data["parent_section_name"] }}) (Opens in new tab)</p>
-              {% else %}
-                  <p class="govuk-body">{{ sub_section_id }}</p>
-              {% endif %}
-          {% endfor %}
+          {{ display_flagged_sections(state, application_id, sections_to_flag) }}
+          <p><strong>Flag allocation</strong><br>{{ 'Flagged for ' + allocated_team if allocated_team else 'N/A' }}</p>
+          {# TODO: Notification is hardcoded. Change it once notification is implemented #}
+          <p><strong>Notification sent</strong><br>No</p>
           </div>
           {{ govukRadios({
           "id": form.resolution_flag.id,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -137,6 +137,9 @@ class DefaultConfig:
     ASSESSMENT_FLAG_ENDPOINT = (
         ASSESSMENT_STORE_API_HOST + "/flag_data?flag_id={flag_id}"
     )
+    ASSESSMENT_FLAGS_ENDPOINT = (
+        ASSESSMENT_STORE_API_HOST + "/flags?application_id={application_id}"
+    )
 
     # Account store endpoints
     BULK_ACCOUNTS_ENDPOINT = ACCOUNT_STORE_API_HOST + "/bulk-accounts"

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -24,7 +24,7 @@ class DevelopmentConfig(DefaultConfig):
     SSO_LOGIN_URL = AUTHENTICATOR_HOST + "/sso/login"
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
 
-    DEBUG_USER_ON = False  # Set to True to use DEBUG user
+    DEBUG_USER_ON = True  # Set to True to use DEBUG user
     SHOW_ALL_ROUNDS = True  # Set to True to show all rounds
 
     DEBUG_USER_ROLE = getenv(

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -300,6 +300,7 @@ class TestAuthorisation:
         ],
     )
     @pytest.mark.application_id("stopped_app")
+    @pytest.mark.flag_id("stopped_app")
     def test_user_levels_have_correct_permissions_to_restart_an_assessment(
         self,
         flask_test_client,
@@ -307,6 +308,7 @@ class TestAuthorisation:
         claim,
         expect_continue_available,
         mock_get_latest_flag,
+        mock_get_flag,
         mock_get_sub_criteria_banner_state,
         mock_get_fund,
     ):
@@ -321,6 +323,7 @@ class TestAuthorisation:
         application_id = request.node.get_closest_marker(
             "application_id"
         ).args[0]
+        flag_id = request.node.get_closest_marker("flag_id").args[0]
         flask_test_client.set_cookie(
             "localhost",
             "fsd_user_token",
@@ -340,7 +343,7 @@ class TestAuthorisation:
             )
         else:
             response = flask_test_client.get(
-                f"assess/continue_assessment/{application_id}",
+                f"assess/continue_assessment/{application_id}?flag_id={flag_id}",
                 follow_redirects=True,
             )
             assert response.status_code == 200

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -791,7 +791,7 @@ class TestJinjaMacros(object):
         reason_heading = alert_div.find("h2", text="Reason")
         assert reason_heading is not None, "Reason heading not found"
         justification = reason_heading.find_next_sibling(
-            "p", class_="govuk-body"
+            "p",
         )
         assert (
             justification is not None
@@ -802,12 +802,21 @@ class TestJinjaMacros(object):
         assert (
             section_heading is not None
         ), "Section(s) flagged heading not found"
-        section = section_heading.find_next_sibling("p", class_="govuk-body")
+        section = section_heading.find_next_sibling("p")
         assert (
             section is not None
             and section.text
-            == "Test section (Parent Test section) (Opens in new tab)"
+            == "Test section (Parent Test section) (Opens in new tab) "
         ), "Section not found"
+
+        notification_heading = alert_div.find("h2", text="Notification sent")
+        assert (
+            notification_heading is not None
+        ), "Notification sent heading not found"
+        notification = notification_heading.find_next_sibling("p")
+        assert (
+            notification is not None and notification.text == "No"
+        ), "Notification not found"
 
         user_info = alert_div.find_all("p", class_="govuk-body-s")
         assert any(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -679,22 +679,25 @@ class TestRoutes:
         )
 
     @pytest.mark.application_id("stopped_app")
+    @pytest.mark.flag_id("stopped_app")
     def test_flag_route_get_continue_application(
         self,
         request,
         flask_test_client,
         mock_get_latest_flag,
+        mock_get_flag,
         mock_get_sub_criteria_banner_state,
         mock_get_fund,
     ):
         application_id = request.node.get_closest_marker(
             "application_id"
         ).args[0]
+        flag_id = request.node.get_closest_marker("flag_id").args[0]
         token = create_valid_token(test_lead_assessor_claims)
         flask_test_client.set_cookie("localhost", "fsd_user_token", token)
 
         response = flask_test_client.get(
-            f"/assess/continue_assessment/{application_id}",
+            f"/assess/continue_assessment/{application_id}?flag_id={flag_id}",
         )
 
         assert response.status_code == 200
@@ -702,7 +705,11 @@ class TestRoutes:
         assert b"Reason for continuing assessment" in response.data
         assert b"Project In prog and Stop" in response.data
 
-    def test_post_continue_application(self, flask_test_client, mocker):
+    @pytest.mark.flag_id("stopped_app")
+    def test_post_continue_application(
+        self, request, flask_test_client, mocker, mock_get_flag
+    ):
+        flag_id = request.node.get_closest_marker("flag_id").args[0]
         token = create_valid_token(test_lead_assessor_claims)
         flask_test_client.set_cookie("localhost", "fsd_user_token", token)
         mocker.patch(
@@ -721,7 +728,7 @@ class TestRoutes:
         )
 
         response = flask_test_client.post(
-            "assess/continue_assessment/app_123",
+            f"assess/continue_assessment/app_123?flag_id={flag_id}",
             data={
                 "reason": "We should continue the application.",
             },


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2771
https://digital.dclg.gov.uk/jira/browse/FS-2664

### Change description
- Added Flag history dropdown in application view page
- Continue assessment page duplicated with [design ](https://fsd-pre-award.herokuapp.com/s39-assessment/40-restart-assessment)
- Remove duplicated code of displaying multiple sections
- Set `DEBUG_USER_ON =TRUE` for development mode



### How to test
This task relies on schema changes from [FS-3024](https://digital.dclg.gov.uk/jira/browse/FS-3024).(which is in progress)
To test this on localhost using mock data, set the `application_id` to your local application [here](https://github.com/communitiesuk/funding-service-design-assessment/blob/a64633d5fb8680864ef0485867b3a1783ea7e7c2/app/assess/data.py#L367)

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/d5065251-2c4d-4090-874c-a5c73355134a)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/c832c681-dcee-4461-ab31-7e15e43c1d8d)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/94de388d-eb14-47ef-9aca-ff22a529c396)

