### PR TITLE
BAU: Fix bulk accounts functionality

### DIFF
--- a/app/assess/auth/validation.py
+++ b/app/assess/auth/validation.py
@@ -108,6 +108,7 @@ def check_access_application_id(
     @wraps(func)
     def decorated_function(*args, **kwargs):
         if Config.FORCE_ALL_FUNDS_ACCESSIBLE:
+            g.access_controller = AllAccessAccessController()
             return func(*args, **kwargs)
 
         application_id = get_application_id_from_request()
@@ -155,6 +156,7 @@ def check_access_fund_short_name(
     @wraps(func)
     def decorated_function(*args, **kwargs):
         if Config.FORCE_ALL_FUNDS_ACCESSIBLE:
+            g.access_controller = AllAccessAccessController()
             return func(*args, **kwargs)
 
         short_name = get_fund_short_name_from_request()
@@ -195,3 +197,17 @@ class AssessmentAccessController(object):
     @property
     def has_any_assessor_role(self) -> bool:
         return self.is_lead_assessor or self.is_assessor
+
+
+class AllAccessAccessController(AssessmentAccessController):
+    @property
+    def is_lead_assessor(self) -> bool:
+        return True
+
+    @property
+    def is_assessor(self) -> bool:
+        return True
+
+    @property
+    def is_commenter(self) -> bool:
+        return True

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -162,11 +162,11 @@ def get_bulk_accounts_dict(account_ids: List, fund_short_name: str):
             del debug_user_config["highest_role"]
             users_result[Config.DEBUG_USER_ACCOUNT_ID] = debug_user_config
 
-        # we only need the highest role for the fund we are currently viewing
-        users_result["highest_role"] = users_result["highest_role_map"][
-            fund_short_name
-        ]
-        del users_result["highest_role_map"]
+        for user_result in users_result.values():
+            # we only need the highest role for the fund we are currently viewing
+            highest_role = user_result["highest_role_map"][fund_short_name]
+            user_result["highest_role"] = highest_role
+            del user_result["highest_role_map"]
 
         return users_result
     else:

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -158,7 +158,9 @@ def get_bulk_accounts_dict(account_ids: List, fund_short_name: str):
         if Config.FLASK_ENV == "development":
             debug_user_config = deepcopy(Config.DEBUG_USER)
             debug_user_config["email_address"] = Config.DEBUG_USER["email"]
-            debug_user_config["highest_role_map"] = {"COF": "LEAD_ASSESSOR"}
+            debug_user_config["highest_role_map"] = {
+                fund_short_name: "LEAD_ASSESSOR"
+            }
             del debug_user_config["highest_role"]
             users_result[Config.DEBUG_USER_ACCOUNT_ID] = debug_user_config
 

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -33,9 +33,15 @@ class DevelopmentConfig(DefaultConfig):
         "email": "dev@example.com",
         "roles": [
             DEBUG_USER_ROLE,
-            "COF_ENGLAND",
             "COF_ASSESSOR",
             "COF_COMMENTER",
+            "COF_ENGLAND",
+            "COF_SCOTLAND",
+            "COF_WALES",
+            "COF_NORTHERNIRELAND",
+            "NSTF_LEAD_ASSESSOR",
+            "NSTF_ASSESSOR",
+            "NSTF_COMMENTER",
         ],
         "highest_role": DEBUG_USER_ROLE,
     }


### PR DESCRIPTION
Issue:

 `users_result` is a dictionary, and we were previously using it as a single object - this should fix the issues we are seeing on assessment at the moment, an oversight on my part.