### PR TITLE
BAU: Change dict to .get so we safely retrieve roles

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -166,7 +166,9 @@ def get_bulk_accounts_dict(account_ids: List, fund_short_name: str):
 
         for user_result in users_result.values():
             # we only need the highest role for the fund we are currently viewing
-            highest_role = user_result["highest_role_map"][fund_short_name]
+            highest_role = user_result["highest_role_map"].get(
+                fund_short_name, ""
+            )
             user_result["highest_role"] = highest_role
             del user_result["highest_role_map"]
 


### PR DESCRIPTION
- Instead of getting roles by using the key `[key]` - we instead use `.get()` with a default of an empty string
- This can happen if a user is un-assigned all their roles, but had left comments/scores/flags etc in the past