### PR TITLE
BAU: Remove duplicate search button for commenters

### DIFF
--- a/app/assess/templates/components/application_overviews_table_cof.html
+++ b/app/assess/templates/components/application_overviews_table_cof.html
@@ -28,9 +28,6 @@
                   <option value='{{ item }}' {% if query_params.asset_type == item %} selected=""{% endif %}>{{ asset_types[item] }}</option>
             {% endfor %}
       </select>
-      {% if not g.access_controller.has_any_assessor_role %}
-        <button class="govuk-button search-button" aria-label="Search" type="submit">Search</button>
-      {% endif %}
     </div>
     {% if g.access_controller.has_any_assessor_role %}
     <div class="govuk-form-group govuk-!-display-inline-block govuk-!-padding-right-2">


### PR DESCRIPTION
On line 44-46, we have a search button shown for all.  But we also had this block showing one for non-assessors, this means they see two search buttons at the moment.  This PR removes the extra one for non-assessors, as we now have a search button for all.