### PR TITLE
FS-3037: Show client side upload files on export page

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -17,8 +17,8 @@ from app.assess.models.fund import Fund
 from app.assess.models.round import Round
 from app.assess.models.score import Score
 from app.assess.models.sub_criteria import SubCriteria
-from boto3 import client
-from botocore.exceptions import ClientError
+from app.aws import generate_url
+from app.aws import list_files_by_prefix
 from config import Config
 from flask import abort
 from flask import current_app
@@ -569,55 +569,6 @@ def submit_comment(
     return response.ok
 
 
-_S3_CLIENT = client(
-    "s3",
-    aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
-    aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
-    region_name=Config.AWS_REGION,
-)
-
-
-def get_file_for_download_from_aws(file_name: str, application_id: str):
-    """_summary_: Function is set up to retrieve
-    files from aws bucket.
-    Args:
-        filename: Takes an filename
-        application_id: Takes an application_id # noqa
-    Returns:
-        Returns a tuple of (file_content, mime_type)
-    """
-
-    if file_name is None:
-        return None
-
-    prefixed_file_name = application_id + "/" + file_name
-
-    try:
-        obj = _S3_CLIENT.get_object(
-            Bucket=Config.AWS_BUCKET_NAME, Key=prefixed_file_name
-        )
-
-        mimetype = obj["ResponseMetadata"]["HTTPHeaders"]["content-type"]
-        data = obj["Body"].read()
-
-        return data, mimetype
-    except ClientError as e:
-        current_app.logger.error(e)
-        raise Exception(e)
-
-
-def list_files_in_folder(prefix):
-    response = _S3_CLIENT.list_objects_v2(
-        Bucket=Config.AWS_BUCKET_NAME, Prefix=prefix
-    )
-    keys = []
-    for obj in response.get("Contents") or []:
-        # we cut off the application id.
-        _, key = obj["Key"].split("/", 1)
-        keys.append(key)
-    return keys
-
-
 def get_files_for_application_upload_fields(
     application_id: str, short_id: str, application_json: dict
 ) -> List[tuple]:
@@ -644,7 +595,8 @@ def get_files_for_application_upload_fields(
                 if field["type"] == "file" and field.get("answer"):
                     file_names.append(field["answer"])
 
-    files = [
+    # files which used the old file upload component
+    legacy_files = [
         (
             file,
             url_for(
@@ -656,7 +608,17 @@ def get_files_for_application_upload_fields(
         )
         for file in file_names
     ]
-    return files
+
+    # files which used the client side file upload component
+    client_side_upload_files = list_files_by_prefix(
+        "feb2bcf2-1e6a-4ba1-8a4e-a9d237c5329a"
+    )
+    files = [
+        (file.filename, generate_url(file, short_id))
+        for file in client_side_upload_files
+    ]
+
+    return legacy_files + files
 
 
 def get_application_json(application_id):

--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -610,9 +610,7 @@ def get_files_for_application_upload_fields(
     ]
 
     # files which used the client side file upload component
-    client_side_upload_files = list_files_by_prefix(
-        "feb2bcf2-1e6a-4ba1-8a4e-a9d237c5329a"
-    )
+    client_side_upload_files = list_files_by_prefix(application_id)
     files = [
         (file.filename, generate_url(file, short_id))
         for file in client_side_upload_files

--- a/app/assess/models/ui/applicants_response.py
+++ b/app/assess/models/ui/applicants_response.py
@@ -5,11 +5,12 @@ from dataclasses import dataclass
 from typing import Iterable
 from typing import List
 from typing import Tuple
+from urllib.parse import quote
 
-from app.assess.data import list_files_in_folder
 from app.assess.views.filters import format_address
 from app.assess.views.filters import format_date
 from app.assess.views.filters import remove_dashes_underscores_capitalize
+from app.aws import list_files_in_folder
 from flask import url_for
 
 ANSWER_NOT_PROVIDED_DEFAULT = "Not provided."
@@ -313,7 +314,8 @@ def _ui_component_from_factory(item: dict, application_id: str):
             key: url_for(
                 "assess_bp.get_file",
                 application_id=application_id,
-                file_name=key,
+                file_name=quote(key, safe=""),
+                quoted=True,
             )
             for key in file_keys
         }

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from urllib.parse import quote_plus
+from urllib.parse import unquote_plus
 
 from app.assess.auth.validation import check_access_application_id
 from app.assess.auth.validation import check_access_fund_short_name
@@ -41,6 +42,7 @@ from app.assess.models.ui.assessor_task_list import AssessorTaskList
 from app.assess.status import all_status_completed
 from app.assess.status import update_ar_status_to_completed
 from app.assess.views.filters import utc_to_bst
+from app.aws import get_file_for_download_from_aws
 from config import Config
 from flask import Blueprint
 from flask import current_app
@@ -704,8 +706,9 @@ def download_application_answers(application_id: str, short_id: str):
     "/application/<application_id>/export/<file_name>",
     methods=["GET"],
 )
-@check_access_application_id
 def get_file(application_id: str, file_name: str):
+    if request.args.get("quoted"):
+        file_name = unquote_plus(file_name)
     short_id = request.args.get("short_id")
     data, mimetype = get_file_for_download_from_aws(
         application_id=application_id, file_name=file_name

--- a/app/assess/templates/components/application_overviews_table_cof.html
+++ b/app/assess/templates/components/application_overviews_table_cof.html
@@ -28,9 +28,6 @@
                   <option value='{{ item }}' {% if query_params.asset_type == item %} selected=""{% endif %}>{{ asset_types[item] }}</option>
             {% endfor %}
       </select>
-      {% if not g.access_controller.has_any_assessor_role %}
-        <button class="govuk-button search-button" aria-label="Search" type="submit">Search</button>
-      {% endif %}
     </div>
     {% if g.access_controller.has_any_assessor_role %}
     <div class="govuk-form-group govuk-!-display-inline-block govuk-!-padding-right-2">

--- a/app/aws.py
+++ b/app/aws.py
@@ -1,0 +1,88 @@
+from collections import namedtuple
+from urllib.parse import quote
+
+from boto3 import client
+from botocore.exceptions import ClientError
+from config import Config
+from flask import current_app
+from flask import url_for
+
+_S3_CLIENT = client(
+    "s3",
+    aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
+    region_name=Config.AWS_REGION,
+)
+
+
+def get_file_for_download_from_aws(file_name: str, application_id: str):
+    """_summary_: Function is set up to retrieve
+    files from aws bucket.
+    Args:
+        filename: Takes an filename
+        application_id: Takes an application_id # noqa
+    Returns:
+        Returns a tuple of (file_content, mime_type)
+    """
+
+    if file_name is None:
+        return None
+
+    prefixed_file_name = application_id + "/" + file_name
+
+    try:
+        current_app.logger.info(
+            f"Retrieving file {prefixed_file_name} from AWS"
+        )
+        obj = _S3_CLIENT.get_object(
+            Bucket=Config.AWS_BUCKET_NAME, Key=prefixed_file_name
+        )
+
+        mimetype = obj["ResponseMetadata"]["HTTPHeaders"]["content-type"]
+        data = obj["Body"].read()
+
+        return data, mimetype
+    except ClientError as e:
+        current_app.logger.error(e)
+        raise Exception(e)
+
+
+def list_files_in_folder(prefix):
+    response = _S3_CLIENT.list_objects_v2(
+        Bucket=Config.AWS_BUCKET_NAME, Prefix=prefix
+    )
+    keys = []
+    for obj in response.get("Contents") or []:
+        # we cut off the application id.
+        _, key = obj["Key"].split("/", 1)
+        keys.append(key)
+    return keys
+
+
+_KEY_PARTS = ("application_id", "form", "path", "component_id", "filename")
+FileData = namedtuple("FileData", _KEY_PARTS)
+
+
+def generate_url(file_data: FileData, short_id: str = "") -> str:
+    generated_url = url_for(
+        "assess_bp.get_file",
+        application_id=file_data.application_id,
+        file_name=quote("/".join(file_data[1:]), safe=""),
+        short_id=short_id or None,
+        quoted=True,
+    )
+    return generated_url
+
+
+def list_files_by_prefix(prefix: str) -> list[FileData]:
+    objects_response = _S3_CLIENT.list_objects_v2(
+        Bucket=Config.AWS_BUCKET_NAME,
+        Prefix=prefix,
+    )
+
+    contents = objects_response.get("Contents") or []
+    return [
+        FileData(*key_parts)
+        for key in [file["Key"] for file in contents]
+        if len(key_parts := key.split("/")) == len(_KEY_PARTS)
+    ]

--- a/tests/test_applicators_response.py
+++ b/tests/test_applicators_response.py
@@ -917,7 +917,7 @@ def test_create_ui_components_retains_order(monkeypatch):
     assert ui_components[11].key_to_url_dict == {
         "form_name/path/name/filename.png": (
             "http://example.org:5000/assess/application/app_123/export/"
-            "form_name/path/name/filename.png"
+            "form_name%252Fpath%252Fname%252Ffilename.png?quoted=True"
         )
     }
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,5 +1,23 @@
 import app
-from app.assess.data import list_files_in_folder
+from app.aws import FileData
+from app.aws import generate_url
+from app.aws import list_files_in_folder
+
+
+def test_generate_url_short_id(app):
+    file_data = FileData("app1", "form1", "path1", "comp1", "file1.txt")
+    assert (
+        generate_url(file_data, "short-id")
+        == "/assess/application/app1/export/form1%252Fpath1%252Fcomp1%252Ffile1.txt?short_id=short-id&quoted=True"
+    )
+
+
+def test_generate_url(app):
+    file_data = FileData("app1", "form1", "path1", "comp1", "file1.txt")
+    assert (
+        generate_url(file_data)
+        == "/assess/application/app1/export/form1%252Fpath1%252Fcomp1%252Ffile1.txt?quoted=True"
+    )
 
 
 def test_list_files_in_folder(monkeypatch):
@@ -23,7 +41,7 @@ def test_list_files_in_folder(monkeypatch):
         }
 
     monkeypatch.setattr(
-        app.assess.data._S3_CLIENT, "list_objects_v2", mock_list_objects_v2
+        app.aws._S3_CLIENT, "list_objects_v2", mock_list_objects_v2
     )
 
     prefix = "app_id/form_name/path/name/"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import app as flask_app
 from app.assess.data import get_files_for_application_upload_fields
 from fsd_utils import extract_questions_and_answers
 from fsd_utils import generate_text_of_application
@@ -49,9 +50,20 @@ class TestExport:
         assert "Q) Capital funding" in result
         assert "A) 2300" in result
 
-    def test_get_files_for_application_upload_fields(self):
+    def test_get_files_for_application_upload_fields(self, monkeypatch, app):
         application_id = "dummy_id"
         short_id = "d_id"
+
+        def mock_list_objects_v2(Bucket, Prefix):  # noqa
+            return {
+                "Contents": [
+                    {"Key": "app_id/form_name/path/name/filename1.png"},
+                ]
+            }
+
+        monkeypatch.setattr(
+            flask_app.aws._S3_CLIENT, "list_objects_v2", mock_list_objects_v2
+        )
 
         with mock.patch(
             "app.assess.data.url_for",
@@ -66,4 +78,9 @@ class TestExport:
         assert ans == [
             ("sample1.doc", "dummy/path/to/file.dmp"),
             ("awskey123123123123123/sample1.doc", "dummy/path/to/file.dmp"),
+            (
+                "filename1.png",
+                "/assess/application/app_id/export/"
+                "form_name%252Fpath%252Fname%252Ffilename1.png?short_id=d_id&quoted=True",
+            ),
         ]


### PR DESCRIPTION
### Change description

- Quote file keys when from client side upload component
- Unquote and pull files from amazon S3 when downloaded
- Move tests & add coverage

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/117724519/16f1f558-3dd6-4309-9750-227fed5a95af)

