### PR TITLE
fixed duplicated teams tab in flag history

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -404,7 +404,7 @@ def get_flags(application_id: str) -> List[FlagV2]:
     else:
         msg = f"flag for application: '{application_id}' not found."
         current_app.logger.warn(msg)
-        return None
+        return []
 
 
 def submit_flag(

--- a/app/assess/models/flag_teams.py
+++ b/app/assess/models/flag_teams.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+from typing import List
+
+from app.assess.models.flag_v2 import FlagTypeV2
+from app.assess.models.flag_v2 import FlagV2
+
+# TODO : Check if there is better way to do it?
+
+
+@dataclass
+class TeamFlagStats:
+    team_name: str
+    num_of_flags: int
+    num_of_resolved: int
+    num_of_raised: int
+    num_of_stopped: int
+    latest_status: FlagTypeV2
+    date_created: str
+    ordinal_list: list
+    flags_list: List[FlagV2]
+
+
+@dataclass
+class TeamsFlagData:
+    teams_stats: dict
+
+    @classmethod
+    def from_flags(cls, flags_list: List[FlagV2], teams_list: list = None):
+        teams_stats = {}
+        ordinal_list = [
+            "First",
+            "Second",
+            "Third",
+            "Fourth",
+            "Fifth",
+        ]  # assume max 5 flags/team
+        if isinstance(flags_list, FlagV2):
+            flags_list = [flags_list]
+
+        if not teams_list:
+            teams_list = [flag.latest_allocation for flag in flags_list]
+            teams_list = list(
+                set(teams_list) - set([None])
+            )  # filter for unique teams
+
+        for team in teams_list:
+            num_of_flags = 0
+            num_of_resolved = 0
+            num_of_raised = 0
+            num_of_stopped = 0
+            latest_status = ""
+            date_created = ""
+            team_flags_list = []
+            # ordinal_list = []
+
+            for flag in flags_list:
+                if flag.latest_allocation == team:
+                    date_created = flag.date_created
+                    latest_status = flag.latest_status
+                    num_of_flags = num_of_flags + 1
+                    team_flags_list.append(flag)
+                    # ordinal_list.append(TeamsFlagData.ordinal(num_of_flags))
+                    if flag.latest_status == FlagTypeV2.RAISED:
+                        num_of_raised = num_of_raised + 1
+                    elif flag.latest_status == FlagTypeV2.RESOLVED:
+                        num_of_resolved = num_of_resolved + 1
+                    elif flag.latest_status == FlagTypeV2.STOPPED:
+                        num_of_stopped = num_of_stopped + 1
+
+            teams_stats[team] = TeamFlagStats(
+                team_name=team,
+                num_of_flags=num_of_flags,
+                num_of_resolved=num_of_resolved,
+                num_of_raised=num_of_raised,
+                num_of_stopped=num_of_stopped,
+                latest_status=latest_status,
+                date_created=date_created,
+                ordinal_list=ordinal_list[0:num_of_flags][::-1],
+                flags_list=team_flags_list[::-1],
+            )
+
+        return cls(teams_stats=teams_stats)
+
+    @staticmethod
+    def ordinal(n: int):
+        if 11 <= (n % 100) <= 13:
+            suffix = "th"
+        else:
+            suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
+        return str(n) + suffix

--- a/app/assess/models/flag_teams.py
+++ b/app/assess/models/flag_teams.py
@@ -14,8 +14,6 @@ class TeamFlagStats:
     num_of_resolved: int
     num_of_raised: int
     num_of_stopped: int
-    latest_status: FlagTypeV2
-    date_created: str
     ordinal_list: list
     flags_list: List[FlagV2]
 
@@ -48,15 +46,11 @@ class TeamsFlagData:
             num_of_resolved = 0
             num_of_raised = 0
             num_of_stopped = 0
-            latest_status = ""
-            date_created = ""
             team_flags_list = []
             # ordinal_list = []
 
             for flag in flags_list:
                 if flag.latest_allocation == team:
-                    date_created = flag.date_created
-                    latest_status = flag.latest_status
                     num_of_flags = num_of_flags + 1
                     team_flags_list.append(flag)
                     # ordinal_list.append(TeamsFlagData.ordinal(num_of_flags))
@@ -73,8 +67,6 @@ class TeamsFlagData:
                 num_of_resolved=num_of_resolved,
                 num_of_raised=num_of_raised,
                 num_of_stopped=num_of_stopped,
-                latest_status=latest_status,
-                date_created=date_created,
                 ordinal_list=ordinal_list[0:num_of_flags][::-1],
                 flags_list=team_flags_list[::-1],
             )

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -33,6 +33,7 @@ from app.assess.helpers import is_flaggable
 from app.assess.helpers import is_qa_complete
 from app.assess.helpers import resolve_application
 from app.assess.helpers import set_application_status_in_overview
+from app.assess.models.flag_teams import TeamsFlagData
 from app.assess.models.flag_v2 import FlagTypeV2
 from app.assess.models.fund_summary import create_fund_summaries
 from app.assess.models.fund_summary import is_after_today
@@ -533,8 +534,8 @@ def application(application_id):
                 accounts_list = get_bulk_accounts_dict(
                     user_id_list, state.fund_short_name
                 )
-    else:
-        flags_list = []
+
+    teams_flag_stats = TeamsFlagData.from_flags(flags_list).teams_stats
 
     sub_criteria_status_completed = all_status_completed(state)
     form = AssessmentCompleteForm()
@@ -552,6 +553,7 @@ def application(application_id):
         state=state,
         application_id=application_id,
         accounts_list=accounts_list,
+        teams_flag_stats=teams_flag_stats,
         flags_list=flags_list,
         current_user_role=g.user.highest_role,
         is_flaggable=is_flaggable(display_status),

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -40,15 +40,17 @@
 
 {% if g.access_controller.has_any_assessor_role %}
 <div>
-    {{ flag_tabs(state, application_id, flags_list, accounts_list) }}
+    {{ flag_tabs(state, application_id, teams_flag_stats, flags_list, accounts_list) }}
 </div>
 {% endif %}
 
-{# TODO: Display multiple flag banner #}
+{# Display multiple flag banner #}
 <div>
-    {% if g.access_controller.has_any_assessor_role and is_qa_complete %}
-        {{ qa_complete_flag(flags_list[-1], accounts_list[flags_list[-1].latest_user_id], form.csrf_token, application_id) }}
-    {% endif %}
+    {% for flag in flags_list %}
+        {% if g.access_controller.has_any_assessor_role and is_qa_complete and flag.latest_status.name == "QA_COMPLETED" %}
+            {{ qa_complete_flag(flag, accounts_list[flag.latest_user_id], form.csrf_token, application_id) }}
+        {% endif %}
+    {% endfor %}
 
     {% for flag in flags_list %}
         {% if g.access_controller.has_any_assessor_role and (display_status != "Stopped") and (flag.latest_status.name == "RAISED") %}
@@ -59,7 +61,7 @@
     {% endfor %}
 
     {% if sub_criteria_status_completed and g.access_controller.has_any_assessor_role and (not is_qa_complete) %}
-        {{ assessment_complete(state, flags_list[-1], form.csrf_token, application_id)}}
+        {{ assessment_complete(state, form.csrf_token, application_id)}}
     {% endif %}
 </div>
 

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -13,7 +13,7 @@
 {% endblock header %}
 
 {% block content %}
-{% if form.errors.get("justification") or form.errors.get("section") %}
+{% if form.errors.get("justification") or form.errors.get("section") or form.errors.get("teams_available") %}
 <div class="govuk-error-summary" data-module="govuk-error-summary">
     <div role="alert">
         <h2 class="govuk-error-summary__title">
@@ -197,6 +197,7 @@
                                     })
                                 }}
                             {% endfor %}
+                            {# Flag Allocation #}
                             <div class="govuk-form-group">
                                 <label class="govuk-label govuk-label--m">Flag allocation</label>
                                 {% set items = [] %}

--- a/app/assess/templates/macros/assessment_completion.html
+++ b/app/assess/templates/macros/assessment_completion.html
@@ -1,8 +1,8 @@
 {% from "macros/link_to_download_contract_docs.html" import link_to_download_contract_docs %}
 
-{% macro assessment_complete(state, flag, csrf_token, application_id) %}
+{% macro assessment_complete(state, csrf_token, application_id) %}
 
-{% if (not flag or flag and flag.latest_status.name=="RESOLVED") and state.workflow_status=="IN_PROGRESS" %}
+{% if state.workflow_status=="IN_PROGRESS" %}
 
 <form method="post" action="{{ url_for('assess_bp.application', application_id=application_id) }}">
     {{ csrf_token }}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -31,7 +31,7 @@
                 <p><strong>Reason</strong><br>{{ data['justification'] }}</p>
                 <p><strong>Section(s) flagged</strong><br></p>
                 {{ display_flagged_sections(state, application_id, flag_data.sections_to_flag) }}
-                <p><strong>Flag allocation</strong><br> <span class="flagged-tag"> {{ "Flagged for"+ data['allocation'] if data['allocation'] else "N/A" }}</span></p>
+                <p><strong>Flag allocation</strong><br> <span class="flagged-tag"> {{ "Flagged for "+ data['allocation'] if data['allocation'] else "N/A" }}</span></p>
                 <p><strong>Notification sent</strong><br>No</p>
             {% else %}
                 {% if data['status'].name=='STOPPED' %}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -12,6 +12,17 @@
     {% endfor %}
 {% endmacro %}
 
+{% macro flag_team_table(state, application_id, teams_flag_stats, accounts_list) %}
+    <h2 class="govuk-heading-l">{{ "Flagged for "+ teams_flag_stats.team_name }}</h2>
+    {% for flag_item in teams_flag_stats.flags_list %}
+        {% if teams_flag_stats.flags_list|length > 1 %}
+            <h3>{{ teams_flag_stats.ordinal_list[loop.index0] }} flag raised</h3>
+        {% endif %}
+        {{ flag_table(state, application_id, flag_item, accounts_list) }}
+    {% endfor %}
+
+{% endmacro %}
+
 {% macro flag_table(state, application_id, flag_data, accounts_list) %}
     {% set items = [] %}
     {% for data in flag_data.updates %}
@@ -45,7 +56,6 @@
                                         {'text': data['status'].name | capitalize}]) %}
     {% endfor %}
 
-    <h2 class="govuk-heading-l">{{ "Flagged for "+ flag_data.latest_allocation if flag_data.latest_allocation else "Flagged" }}</h2>
     {{ govukTable({
     'head': [
         {'text': "Created by"},
@@ -57,19 +67,17 @@
     })}}
 {% endmacro %}
 
-{% macro flag_tabs(state, application_id, flags_list, accounts_list) %}
+{% macro flag_tabs(state, application_id, teams_flag_stats, flags_list, accounts_list) %}
     {% set TabsData %}
         {% set items = [] %}
-        {% for flag_item in flags_list %}
-            {% if flag_item.latest_status.name != "QA_COMPLETED" %}
+        {% for team, stats in teams_flag_stats.items() %}
                 {% set addItem = items.append({
-                'label': ("Flagged for " + flag_item.latest_allocation) if flag_item.latest_allocation else ("Flag " + (loop.index0 +1) | string),
-                'id': "tab-" + (flag_item.latest_allocation | replace(" ", "-") if flag_item.latest_allocation else loop.index0 | string),
+                'label': ("Flagged for " + team),
+                'id': "tab-" + (team | replace(" ", "-")),
                 'panel': {
-                    'html': flag_table(state, application_id, flag_item, accounts_list)}
+                    'html': flag_team_table(state, application_id, stats, accounts_list)}
                 })%}
                 {# <p>items: {{ flag_table(state, application_id, flag_item, accounts_list) }}</p> #}
-            {% endif %}
         {% endfor %}
 
         {{ govukTabs({

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -843,12 +843,11 @@ class TestJinjaMacros(object):
 
     def test_assessment_completion_state_completed(self, request_ctx):
         rendered_html = render_template_string(
-            "{{assessment_complete(state, flag, csrf_token, application_id)}}",
+            "{{assessment_complete(state, csrf_token, application_id)}}",
             assessment_complete=get_template_attribute(
                 "macros/assessment_completion.html", "assessment_complete"
             ),
             state=type("State", (), {"workflow_status": "COMPLETED"})(),
-            flag=None,
             csrf_token=generate_csrf(),
             application_id=1,
             g=default_flask_g(),
@@ -868,20 +867,11 @@ class TestJinjaMacros(object):
 
     def test_assessment_completion_flagged(self, request_ctx):
         rendered_html = render_template_string(
-            "{{assessment_complete(state, flag, csrf_token, application_id)}}",
+            "{{assessment_complete(state, srf_token, application_id)}}",
             assessment_complete=get_template_attribute(
                 "macros/assessment_completion.html", "assessment_complete"
             ),
             state=type("State", (), {"workflow_status": "IN_PROGRESS"})(),
-            flag=type(
-                "Flag",
-                (),
-                {
-                    "latest_status": type(
-                        "FlagTypeV2", (), {"name": "RESOLVED"}
-                    )
-                },
-            )(),
             csrf_token=generate_csrf(),
             application_id=1,
             g=default_flask_g(),


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3143
https://dluhcdigital.atlassian.net/browse/FS-3141
https://dluhcdigital.atlassian.net/browse/FS-3142

### Description
- Fixed duplicated teams tab in flag history
- Unit tests and other appropriate tests updated
- `flag_teams.py` is a brief concept. Need to rework in future

### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
**Before fix**
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/8e38da5d-1dfe-412e-bdc6-0285a868c72f)

**After fix**
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/e91dd200-e583-4edb-b549-e30d22cbdb07)
