### PR TITLE
Fs 2776 display assessment status

### DIFF
--- a/app/assess/display_value_mappings.py
+++ b/app/assess/display_value_mappings.py
@@ -24,7 +24,7 @@ assessment_statuses = {
     "QA_COMPLETED": "QA complete",
     "FLAGGED": "Flagged",
     "STOPPED": "Stopped",
-    "MULTIPLE_FLAGS": "Multiple Flags To Resolve",
+    "MULTIPLE_FLAGS": "Multiple flags to resolve",
 }
 
 funding_types = {

--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -1,7 +1,6 @@
 import time
 from typing import List
 
-from app.assess.data import get_application_metadata
 from app.assess.data import get_flags
 from app.assess.data import get_fund
 from app.assess.data import get_sub_criteria_banner_state
@@ -39,13 +38,8 @@ def get_fund_short_name_from_request() -> str | None:
     return fund_short_name
 
 
-def determine_display_status(workflow_status: str, Flags: List[FlagV2]) -> str:
-    """
-    Deduce whether to override display_status with a
-    flag.
-    """
-    display_status = ""
-
+def determine_flag_status(Flags: List[FlagV2]) -> str:
+    flag_status = ""
     flags_list = (
         [
             (FlagV2.from_dict(flag) if isinstance(flag, dict) else flag)
@@ -57,18 +51,25 @@ def determine_display_status(workflow_status: str, Flags: List[FlagV2]) -> str:
     all_latest_status = [flag.latest_status for flag in flags_list]
 
     if FlagTypeV2.STOPPED in all_latest_status:
-        display_status = "Stopped"
+        flag_status = "Stopped"
     elif all_latest_status.count(FlagTypeV2.RAISED) > 1:
-        display_status = "Multiple Flags To Resolve"
+        flag_status = "Multiple flags to resolve"
     elif all_latest_status.count(FlagTypeV2.RAISED) == 1:
         for flag in flags_list:
             if flag.latest_status == FlagTypeV2.RAISED:
-                display_status = (
+                flag_status = (
                     ("Flagged for " + flag.latest_allocation)
                     if flag.latest_allocation
                     else "Flagged"
                 )
-    elif FlagTypeV2.QA_COMPLETED in all_latest_status:
+    return flag_status
+
+
+def determine_display_status(workflow_status: str, Flags: List[FlagV2]) -> str:
+    flag_status = determine_flag_status(Flags)
+    if flag_status:
+        display_status = flag_status
+    elif is_qa_complete(Flags):
         display_status = "QA complete"
     else:
         display_status = assessment_statuses[workflow_status]
@@ -76,11 +77,23 @@ def determine_display_status(workflow_status: str, Flags: List[FlagV2]) -> str:
     return display_status
 
 
-def is_flaggable(display_status: str):
-    return display_status != "Stopped"
+def determine_assessment_status(
+    workflow_status: str, Flags: List[FlagV2]
+) -> str:
+    if is_qa_complete(Flags):
+        assessment_status = "QA complete"
+    else:
+        assessment_status = assessment_statuses[workflow_status]
+
+    return assessment_status
+
+
+def is_flaggable(flag_status: str):
+    return flag_status != "Stopped"
 
 
 def is_qa_complete(Flags: List[FlagV2]) -> bool:
+    # TODO: Rework on this when QA_COMPLETED is moved to assessment enum type
     flags_list = (
         [
             (FlagV2.from_dict(flag) if isinstance(flag, dict) else flag)
@@ -160,12 +173,13 @@ def resolve_application(
         )
     sub_criteria_banner_state = get_sub_criteria_banner_state(application_id)
     flags_list = get_flags(application_id)
-    display_status = determine_display_status(
+    assessment_status = determine_assessment_status(
         state.workflow_status
         if state
-        else get_application_metadata(application_id)["workflow_status"],
+        else sub_criteria_banner_state.workflow_status,
         flags_list,
     )
+    flag_status = determine_flag_status(flags_list)
 
     fund = get_fund(sub_criteria_banner_state.fund_id)
     return render_template(
@@ -175,7 +189,8 @@ def resolve_application(
         sub_criteria=sub_criteria_banner_state,
         form=form,
         referrer=request.referrer,
-        display_status=display_status,
+        assessment_status=assessment_status,
+        flag_status=flag_status,
         state=state,
         sections_to_flag=section,
         reason_to_flag=reason_to_flag,

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -31,7 +31,8 @@
         state.short_id,
         state.project_name,
         state.funding_amount_requested,
-        display_status,
+        assessment_status,
+        flag_status
     ) }}
 </header>
 {% endblock header %}
@@ -53,9 +54,9 @@
     {% endfor %}
 
     {% for flag in flags_list %}
-        {% if g.access_controller.has_any_assessor_role and (display_status != "Stopped") and (flag.latest_status.name == "RAISED") %}
+        {% if g.access_controller.has_any_assessor_role and (flag_status != "Stopped") and (flag.latest_status.name == "RAISED") %}
             {{ assessment_flagged(state, flag, accounts_list[flag.latest_user_id], application_id) }}
-        {% elif g.access_controller.has_any_assessor_role and display_status == "Stopped" and (flag.latest_status.name == "STOPPED")%}
+        {% elif g.access_controller.has_any_assessor_role and flag_status == "Stopped" and (flag.latest_status.name == "STOPPED")%}
             {{ assessment_stopped(flag, accounts_list[flag.latest_user_id], application_id) }}
         {% endif %}
     {% endfor %}
@@ -84,7 +85,7 @@
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-top-2 govuk-button-group">
             <span>
-                {% if g.access_controller.is_lead_assessor and state.workflow_status=="COMPLETED" and (not is_qa_complete) and display_status not in ["Stopped", "Flagged", "Multiple Flags To Resolve"] and "Flagged" not in display_status %}
+                {% if g.access_controller.is_lead_assessor and state.workflow_status=="COMPLETED" and (not is_qa_complete) and flag_status not in ["Stopped", "Flagged", "Multiple flags to resolve"] and "Flagged" not in flag_status %}
                 {{ mark_qa_complete_button(application_id) }}
                 {% endif %}
             </span>

--- a/app/assess/templates/components/header.html
+++ b/app/assess/templates/components/header.html
@@ -16,6 +16,7 @@
         sub_criteria.short_id,
         sub_criteria.project_name,
         sub_criteria.funding_amount_requested,
-        display_status
+        assessment_status,
+        flag_status
     ) }}
 </header>

--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -1,4 +1,4 @@
-{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, display_status) %}
+{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, assessment_status, flag_status) %}
 
 <div class="fsd-banner-background">
     <div class="govuk-width-container">
@@ -9,9 +9,9 @@
                     <h2 class="govuk-heading-l fsd-banner-content">Project reference: {{ project_reference | format_project_ref }}</h2>
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">Project name: {{ project_name }}</h3>
                     <h3 class="govuk-body-l fsd-banner-content">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
-
-                    {% if g.access_controller.has_any_assessor_role %}
-                        <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">{{ display_status | all_caps_to_human }}</h3>
+                    <h3 class="govuk-body-l fsd-banner-content">Assessment status: {{ assessment_status }}</h3>
+                    {% if g.access_controller.has_any_assessor_role and (("Flagged" in  flag_status) or (flag_status in ["Multiple flags to resolve", "Stopped", "Flagged"])) %}
+                        <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">{{ flag_status or "" }}</h3>
                     {% endif %}
                 </div>
             </div>

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -85,7 +85,7 @@
         }) }}
     {% endset %}
 
-    <details class="govuk-details" data-module="govuk-details" open="">
+    <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
             Flag history

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,10 +281,6 @@ def mock_get_application_metadata():
                 "assessment_store/applications/{application_id}"
             ],
         ),
-        mock.patch(
-            "app.assess.helpers.get_application_metadata",
-            return_value=mock_api_results["/application/stopped_app/metadata"],
-        ),
     ):
         yield
 

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -583,11 +583,12 @@ class TestJinjaMacros(object):
         project_reference = "TEST123"
         project_name = "Test Project"
         funding_amount_requested = 123456.78
-        workflow_status = "SUBMITTED"
+        assessment_status = "Submitted"
+        flag_status = "Flagged"
 
         rendered_html = render_template_string(
             "{{ banner_summary(fund_name, project_reference, project_name,"
-            " funding_amount_requested, workflow_status) }}",
+            " funding_amount_requested, assessment_status, flag_status) }}",
             banner_summary=get_template_attribute(
                 "macros/banner_summary.html", "banner_summary"
             ),
@@ -595,7 +596,8 @@ class TestJinjaMacros(object):
             project_reference=project_reference,
             project_name=project_name,
             funding_amount_requested=funding_amount_requested,
-            workflow_status=workflow_status,
+            assessment_status=assessment_status,
+            flag_status=flag_status,
             g=default_flask_g(),
         )
 
@@ -620,19 +622,25 @@ class TestJinjaMacros(object):
             text="Total funding requested: £123,456.78",
         ), "Funding amount not found"
         assert soup.find(
-            "h3", class_="fsd-banner-content", text="Submitted"
-        ), "Workflow status not found"
+            "h3",
+            class_="fsd-banner-content",
+            text="Assessment status: Submitted",
+        ), "Assessment status not found"
+        assert soup.find(
+            "h3", class_="fsd-banner-content", text="Flagged"
+        ), "Flag status not found"
 
     def test_stopped_flag_macro(self, request_ctx):
         fund_name = "Test Fund"
         project_reference = "TEST123"
         project_name = "Test Project"
         funding_amount_requested = 123456.78
-        display_status = "STOPPED"
+        assessment_status = "In progress"
+        flag_status = "Stopped"
 
         rendered_html = render_template_string(
             "{{ banner_summary(fund_name, project_reference, project_name,"
-            " funding_amount_requested, display_status) }}",
+            " funding_amount_requested, assessment_status, flag_status) }}",
             banner_summary=get_template_attribute(
                 "macros/banner_summary.html", "banner_summary"
             ),
@@ -640,7 +648,8 @@ class TestJinjaMacros(object):
             project_reference=project_reference,
             project_name=project_name,
             funding_amount_requested=funding_amount_requested,
-            display_status=display_status,
+            assessment_status=assessment_status,
+            flag_status=flag_status,
             g=default_flask_g(),
         )
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-2776

### Change description
- Added assessment status in the blue banner (`Not started`, `In progress`, `Qa completed`,  `Assessment completed`)
- Flag status shows as when available(`Multiple flags to resolve`, `Flagged for [TeamA]`, `Stopped`) 
- Unit tests and other appropriate tests are updated


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/7371dfe9-6683-450b-a641-5c73cf408ca9)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/e77886c1-f00e-4623-afaa-9b25a350492a)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/af2845ba-6565-4708-9097-019ae0a8caad)


