### PR TITLE
FS-3184: Add "All uploaded documents" functionality

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -453,6 +453,29 @@ def submit_flag(
         return FlagV2.from_dict(flag_json)
 
 
+def get_all_uploaded_documents_theme_answers(
+    application_id: str,
+) -> Union[list, None]:
+    all_uploaded_documents_theme_answers_endpoint = (
+        Config.ALL_UPLOADED_DOCUMENTS_THEME_ANSWERS_ENDPOINT.format(
+            application_id=application_id
+        )
+    )
+    all_uploaded_documents_theme_answers_response = get_data(
+        all_uploaded_documents_theme_answers_endpoint
+    )
+
+    if all_uploaded_documents_theme_answers_response:
+        return all_uploaded_documents_theme_answers_response
+    else:
+        msg = (
+            f"all_uploaded_documents_theme_answers: '{application_id}' not"
+            " found."
+        )
+        current_app.logger.warn(msg)
+        abort(404, description=msg)
+
+
 def get_sub_criteria_theme_answers(
     application_id: str, theme_id: str
 ) -> Union[list, None]:

--- a/app/assess/models/fund.py
+++ b/app/assess/models/fund.py
@@ -11,6 +11,7 @@ class Fund:
     id: str
     description: str
     short_name: str
+    all_uploaded_documents_section_available: bool
     rounds: List[Round] = field(default_factory=list)
 
     @staticmethod
@@ -20,6 +21,10 @@ class Fund:
             id=data.get("id"),
             description=data.get("description"),
             short_name=data.get("short_name"),
+            all_uploaded_documents_section_available=data.get(
+                "all_uploaded_documents_section_available"
+            )
+            or False,
         )
 
     def add_round(self, fund_round: Round):

--- a/app/assess/templates/all_uploaded_documents.html
+++ b/app/assess/templates/all_uploaded_documents.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% from "macros/theme.html" import theme %}
+{% from "macros/sub_criteria_navbar.html" import navbar %}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/flag_application_button.html" import flag_application_button %}
+{% set pageHeading -%}
+All uploaded documents
+{% endset %}
+
+{% block header %}
+{% include "./components/header.html" %}
+{% endblock header %}
+
+{% block content %}
+
+{% if is_flaggable and g.access_controller.has_any_assessor_role %}
+    {{ flag_application_button(application_id) }}
+{% endif %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third content-container">
+        <h2 class="govuk-heading-l scoring-heading">All uploaded documents</h2>
+    </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-one-third">
+            {{ navbar(
+                application_id,
+                {'themes': [{'id': 'all_uploaded_documents', 'name': 'All uploaded documents'}]},
+                "all_uploaded_documents"
+            ) }}
+        </div>
+        <div class="theme govuk-grid-column-two-thirds">
+            {{ theme(answers_meta)}}
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -69,6 +69,14 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-grid-column-two-thirds">
+            {% if all_uploaded_documents_section_available %}
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">All uploaded documents</h2>
+            {{ section_element(
+                "",
+                [{'id': 'all_uploaded_documents', 'name': 'All uploaded documents'}],
+                application_id
+            ) }}
+            {% endif %}
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Unscored</h2>
             {% for section in state.sections %}
                 {{ section_element(section.name, section.sub_criterias, application_id) }}

--- a/app/assess/templates/components/header.html
+++ b/app/assess/templates/components/header.html
@@ -13,9 +13,9 @@
 
     {{ banner_summary(
         (state.fund_name if state else fund.name),
-        sub_criteria.short_id,
-        sub_criteria.project_name,
-        sub_criteria.funding_amount_requested,
+        sub_criteria.short_id if sub_criteria else state.short_id,
+        sub_criteria.project_name if sub_criteria else state.project_name,
+        sub_criteria.funding_amount_requested if sub_criteria else state.funding_amount_requested,
         assessment_status,
         flag_status
     ) }}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -121,6 +121,11 @@ class DefaultConfig:
         ASSESSMENT_STORE_API_HOST + "/application/{application_id}/metadata"
     )
 
+    ALL_UPLOADED_DOCUMENTS_THEME_ANSWERS_ENDPOINT = (
+        ASSESSMENT_STORE_API_HOST
+        + "/application/{application_id}/all_uploaded_documents"
+    )
+
     SUB_CRITERIA_THEME_ANSWERS_ENDPOINT = (
         "/sub_criteria_themes/{application_id}/{theme_id}"
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -135,6 +135,7 @@ def test_generate_csv_of_application():
         id="fund-uuid",
         description="Test Fund Description",
         short_name="Test Short Name",
+        all_uploaded_documents_section_available=True,
     )
 
     application = {


### PR DESCRIPTION
### Change description

- Adds a new psuedo-theme, "all_uploaded_documents"
- This acts as a theme, but instead just gives all answers with documents
- No comments should be shown on this page
- You can not score this page

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines


### How to test

- Deploy this branch, or make it available somewhere
- Go to a COF application
- Observe the new section "All uploaded documents"
- You can click and observe answers, and download as usual
- You can not comment or score this section/theme

### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/117724519/30a7d17e-1b80-4c93-8599-47aed75f083e)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/117724519/7adc35b1-05eb-424f-b4ea-47dcf0aea806)


### Related 

- https://github.com/communitiesuk/funding-service-design-assessment-store/pull/227
- https://github.com/communitiesuk/funding-service-design-fund-store/pull/100

