### PR TITLE
FS-3140-no-spacing-in-targeted-criteria-theme

### DIFF
--- a/app/assess/templates/macros/theme/question_above_answer_html.jinja2
+++ b/app/assess/templates/macros/theme/question_above_answer_html.jinja2
@@ -1,6 +1,6 @@
 {% macro question_above_answer_html(meta) %}
 
     <h2 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h2>
-    <span class="govuk-body"> {{ meta.answer | safe }} </span>
+    <p class="govuk-body"> {{ meta.answer | safe }} </p>
 
 {% endmacro %}


### PR DESCRIPTION
### Ticket 
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?view=detail&selectedIssue=FS-3140

### Description

This PR fixes the spacing issue in the **targeted criteria theme** answer 

### Screenshot

![Screenshot 2023-07-12 at 10 29 02](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/b0b98ff9-3c26-4fac-8573-fb7f6fcd121d)

