### PR TITLE
FS-3179 - Status is now hidden from commenters to match the prototype.

### DIFF
--- a/app/assess/templates/macros/banner_summary.html
+++ b/app/assess/templates/macros/banner_summary.html
@@ -9,7 +9,9 @@
                     <h2 class="govuk-heading-l fsd-banner-content">Project reference: {{ project_reference | format_project_ref }}</h2>
                     <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">Project name: {{ project_name }}</h3>
                     <h3 class="govuk-body-l fsd-banner-content">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</h3>
+                    {% if g.access_controller.has_any_assessor_role %}
                     <h3 class="govuk-body-l fsd-banner-content">Assessment status: {{ assessment_status }}</h3>
+                    {% endif %}
                     {% if g.access_controller.has_any_assessor_role and (("Flagged" in  flag_status) or (flag_status in ["Multiple flags to resolve", "Stopped", "Flagged"])) %}
                         <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">{{ flag_status or "" }}</h3>
                     {% endif %}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3179

### Change description
Commenters will no longer see the assessment statement to match the prototype 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have only the commenter role and see that the assessment status no longer appears

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/9859409c-e295-4c05-b99f-a5673120b835)
