### PR TITLE
BAU: Bump Assessment Frontend memory Test env to 512mb

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
     - form-uploads-dev
 
 - name: funding-service-design-assessment-test
-  memory: 256M
+  memory: 512M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py


### PR DESCRIPTION
### Change description

Bump assessment frontend memory to reduce performance degradation on Test Env and allow e2e tests for Assessment to run smoothly on Test env.



### How to test
N/A


### Screenshots of UI changes (if applicable)
N/A
