### PR TITLE
Fs 3128 flag banners for resolve stopped continue

### DIFF
--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -9,6 +9,7 @@
 {% from "macros/mark_qa_complete_button.html" import mark_qa_complete_button %}
 {% from "macros/assessment_flag.html" import assessment_flagged %}
 {% from "macros/assessment_flag.html" import assessment_stopped %}
+{% from "macros/assessment_flag.html" import assessment_resolved %}
 {% from "macros/logout_partial.html" import logout_partial %}
 {% from "macros/qa_complete_flag.html" import qa_complete_flag %}
 {% from "macros/assessment_completion.html" import assessment_complete %}
@@ -54,14 +55,16 @@
     {% endfor %}
 
     {% for flag in flags_list %}
-        {% if g.access_controller.has_any_assessor_role and (flag_status != "Stopped") and (flag.latest_status.name == "RAISED") %}
+        {% if g.access_controller.has_any_assessor_role and (flag_status != "Stopped") and (flag.latest_status.name == "RESOLVED") %}
+            {{ assessment_resolved(flag, accounts_list[flag.latest_user_id], application_id) }}
+        {% elif g.access_controller.has_any_assessor_role and (flag_status != "Stopped") and (flag.latest_status.name == "RAISED") %}
             {{ assessment_flagged(state, flag, accounts_list[flag.latest_user_id], application_id) }}
         {% elif g.access_controller.has_any_assessor_role and flag_status == "Stopped" and (flag.latest_status.name == "STOPPED")%}
             {{ assessment_stopped(flag, accounts_list[flag.latest_user_id], application_id) }}
         {% endif %}
     {% endfor %}
 
-    {% if sub_criteria_status_completed and g.access_controller.has_any_assessor_role and (not is_qa_complete) %}
+    {% if sub_criteria_status_completed and g.access_controller.has_any_assessor_role and (not is_qa_complete) and (not flag_status) %}
         {{ assessment_complete(state, form.csrf_token, application_id)}}
     {% endif %}
 </div>

--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -54,6 +54,7 @@
         {% endif %}
     {% endfor %}
 
+    {# only show stopped banner, if flag_status=="Stopped" and hide all other banners #}
     {% for flag in flags_list %}
         {% if g.access_controller.has_any_assessor_role and (flag_status != "Stopped") and (flag.latest_status.name == "RESOLVED") %}
             {{ assessment_resolved(flag, accounts_list[flag.latest_user_id], application_id) }}

--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -26,17 +26,45 @@
 
 {% macro assessment_stopped(flag, user_info, application_id) %}
     <div class="assessment-alert assessment-alert--stopped" role="alert">
-        <h1 class="assessment-alert__heading govuk-heading-l">Assessment {{ flag.latest_status.name | title }}</h1>
+        <h1 class="assessment-alert__heading govuk-heading-l">
+            {{ ("Flagged for "+ flag.latest_allocation if flag.latest_allocation else "Flagged") +  " - Assessment stopped" }}
+        </h1>
         <h2 class="govuk-heading-m">Reason</h2>
         {% for update in flag.updates %}
             {% if update["status"].name == "STOPPED" %}
                 <p class="govuk-body">{{ update["justification"] }}</p>
             {% endif %}
         {% endfor %}
+        <br>
         <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | utc_to_bst }}</p>
         {% if g.access_controller.is_lead_assessor %}
             <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.continue_assessment',application_id=application_id)}}?flag_id={{ flag.id }}">Remove flag and continue assessment</a></p>
         {% endif %}
+    </div>
+{% endmacro %}
+
+{% macro assessment_resolved(flag, user_info, application_id) %}
+    <div class="assessment-complete  govuk-margin-bottom-8" role="alert">
+        {% if flag.updates[-1]["status"].name == "RESOLVED" %}
+            {% if flag.updates[-2]["status"].name == "STOPPED" %}
+                <h1 class="assessment-alert__heading govuk-heading-l">
+                    {{ ("Flagged for "+ flag.latest_allocation if flag.latest_allocation else "Flagged") + " - Continue assessment" }}
+                </h1>
+                <h2>Reason for continuing assessment</h2>
+                <p>{{ flag.updates[-1]["justification"] }}</p>
+            {% else %}
+                <h1 class="assessment-alert__heading govuk-heading-l">
+                    {{ ("Flagged for "+ flag.latest_allocation if flag.latest_allocation else "Flagged") + " resolved" }}
+                </h1>
+                <h2>Resolve flag action</h2>
+                <p>Query resolved</p>
+                <h2>Reason</h2>
+                <p>{{ flag.updates[-1]["justification"] }}</p>
+            {% endif %}
+        {% endif %}
+        <br>
+        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
+        <p class="govuk-body-s">{{ flag.updates[-1]["date_created"] | utc_to_bst }}</p>
     </div>
 {% endmacro %}

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -67,9 +67,17 @@ resolved_app = {
                     "user_id": test_user_id_lead_assessor,
                     "date_created": "2023-02-20 12:00:00",
                     "justification": "Test",
+                    "status": "RAISED",
+                    "allocation": None,
+                },
+                {
+                    "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
+                    "user_id": test_user_id_lead_assessor,
+                    "date_created": "2023-02-20 12:00:00",
+                    "justification": "Test",
                     "status": "RESOLVED",
                     "allocation": None,
-                }
+                },
             ],
         },
     ],

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -717,6 +717,7 @@ class TestJinjaMacros(object):
             ),
             flag={
                 "latest_status": {"name": "STOPPED"},
+                "latest_allocation": "Team A",
                 "updates": [
                     {
                         "justification": "Test justification",
@@ -741,8 +742,8 @@ class TestJinjaMacros(object):
         assert (
             alert_div.find(
                 "h1", class_="assessment-alert__heading govuk-heading-l"
-            ).text
-            == "Assessment Stopped"
+            ).text.strip()
+            == "Flagged for Team A - Assessment stopped"
         ), "Flag type not found"
 
         assert (

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -643,14 +643,14 @@ class TestRoutes:
         assert 200 == response.status_code, "Wrong status code on response"
         soup = BeautifulSoup(response.data, "html.parser")
         assert (
-            soup.find("h1", class_="assessment-alert__heading").string
-            == "Assessment Stopped"
+            soup.find("h1", class_="assessment-alert__heading").string.strip()
+            == "Flagged - Assessment stopped"
         )
         assert b"Lead User (Lead assessor) lead@test.com" in response.data
         assert b"20/02/2023 at 12:00" in response.data
 
     @pytest.mark.application_id("resolved_app")
-    def test_application_route_should_not_show_resolved_flag(
+    def test_application_route_should_show_resolved_flag(
         self,
         request,
         flask_test_client,
@@ -672,12 +672,10 @@ class TestRoutes:
         )
 
         assert response.status_code == 200
-        # TODO: Uncomment & fix it after multiple flags is implemented (FS-2776)
-        # assert b"Remove flag" not in response.data
-        # assert b"Resolve flag" not in response.data
-        # assert b"Reason" not in response.data
-        # assert b"flagged" not in response.data
-        # assert b"Flagged" not in response.data
+        assert b"Remove flag" not in response.data
+        assert b"Flagged resolved" in response.data
+        assert b"Resolve flag action" in response.data
+        assert b"Reason" in response.data
 
     @pytest.mark.application_id("resolved_app")
     def test_flag_route_submit_flag(


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3128
https://dluhcdigital.atlassian.net/browse/FS-3129

### Change description
- Implemented flag banners for resolve, continue & stopped status
- Unit tests and other appropriate tests added or updated

Design references:
https://fsd-pre-award.herokuapp.com/s39-assessment/30-history-stopped
https://fsd-pre-award.herokuapp.com/s39-assessment/40-history-restart
https://fsd-pre-award.herokuapp.com/s39-assessment/20-history-resolved#s26-team-allocation-2

### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/40bf0d02-cb6c-4606-bf6a-e96d80835ac1)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/96813c07-af29-4a85-8fb6-57abc6b31979)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/35c8b205-0d40-4e8a-a7f8-dde3bcf04107)

