### PR TITLE
Checkbox no longer wipes when a error occurs

### DIFF
--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -94,7 +94,8 @@
                             {% if section.name == 'Unscored' %}
                                 {% for sub_section in section.sub_criterias %}
                                     {% set addItem = items.append({'value': sub_section["id"],
-                                                                    'text': sub_section["name"]}) %}
+                                                                    'text': sub_section["name"],
+                                                                    'checked':  sub_section["id"] in form.section.data}) %}
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
@@ -104,7 +105,8 @@
                                 {% if section.name == 'Your organisation' %}
                                     {% for sub_section in section.sub_criterias %}
                                         {% set addItem = items.append({'value': sub_section["id"],
-                                                                        'text': sub_section["name"]}) %}
+                                                                        'text': sub_section["name"],
+                                                                        'checked':  sub_section["id"] in form.section.data}) %}
                                     {% endfor %}
                                 {% endif %}
                             {% endfor %}

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -148,7 +148,8 @@
                             {% if section.name == 'Declarations' %}
                                 {% for sub_section in section.sub_criterias %}
                                     {% set addItem = items.append({'value': sub_section["id"],
-                                                                'text': sub_section["name"]}) %}
+                                                                'text': sub_section["name"],
+                                                                'checked':  sub_section["id"] in form.section.data }) %}
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
@@ -180,7 +181,8 @@
                                 {% set items = [] %}
                                 {% for sub_section in section.sub_criterias %}
                                     {% set addItem = items.append({'value': sub_section["id"],
-                                                                'text': sub_section["name"]}) %}
+                                                                'text': sub_section["name"],
+                                                                'checked':  sub_section["id"] in form.section.data }) %}
                                 {% endfor %}
                                 {{ govukCheckboxes({
                                     'idPrefix': section["name"],

--- a/app/assess/templates/flag_application.html
+++ b/app/assess/templates/flag_application.html
@@ -93,9 +93,13 @@
                         {% for section in state.sections %}
                             {% if section.name == 'Unscored' %}
                                 {% for sub_section in section.sub_criterias %}
+                                    {% set checked = False %}
+                                    {% if form.section.data and (sub_section["id"] in form.section.data) %}
+                                        {% set checked = True %}
+                                    {% endif %}
                                     {% set addItem = items.append({'value': sub_section["id"],
                                                                     'text': sub_section["name"],
-                                                                    'checked':  sub_section["id"] in form.section.data}) %}
+                                                                    'checked': checked}) %}
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
@@ -104,9 +108,13 @@
                             {% for section in state.sections %}
                                 {% if section.name == 'Your organisation' %}
                                     {% for sub_section in section.sub_criterias %}
+                                        {% set checked = False %}
+                                        {% if form.section.data and (sub_section["id"] in form.section.data) %}
+                                            {% set checked = True %}
+                                        {% endif %}
                                         {% set addItem = items.append({'value': sub_section["id"],
                                                                         'text': sub_section["name"],
-                                                                        'checked':  sub_section["id"] in form.section.data}) %}
+                                                                        'checked': checked}) %}
                                     {% endfor %}
                                 {% endif %}
                             {% endfor %}
@@ -149,9 +157,13 @@
                         {% for section in state.sections %}
                             {% if section.name == 'Declarations' %}
                                 {% for sub_section in section.sub_criterias %}
+                                    {% set checked = False %}
+                                    {% if form.section.data and (sub_section["id"] in form.section.data) %}
+                                        {% set checked = True %}
+                                    {% endif %}
                                     {% set addItem = items.append({'value': sub_section["id"],
                                                                 'text': sub_section["name"],
-                                                                'checked':  sub_section["id"] in form.section.data }) %}
+                                                                'checked': checked}) %}
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
@@ -182,9 +194,13 @@
                             {% for section in state.criterias %}
                                 {% set items = [] %}
                                 {% for sub_section in section.sub_criterias %}
+                                    {% set checked = False %}
+                                    {% if form.section.data and (sub_section["id"] in form.section.data) %}
+                                        {% set checked = True %}
+                                    {% endif %}
                                     {% set addItem = items.append({'value': sub_section["id"],
                                                                 'text': sub_section["name"],
-                                                                'checked':  sub_section["id"] in form.section.data }) %}
+                                                                'checked': checked }) %}
                                 {% endfor %}
                                 {{ govukCheckboxes({
                                     'idPrefix': section["name"],


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3102

### Change description
Checkbox will no longer remove the selected entries when there is a validation error

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

- Click flag application
- Select form sections to flag but leave the reason got flagging box empty to cause an error
- See that selected checkboxs have remained selected

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/01042615-9658-4993-a8fb-98494f7e0a8e)
