### PR TITLE
BAU: Add 403 forbidden template and handler

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -11,6 +11,7 @@ from app.assess.views.filters import slash_separated_day_month_year
 from app.assess.views.filters import utc_to_bst
 from app.assets import compile_static_assets
 from app.auth import auth_protect
+from app.default.routes import forbidden
 from config import Config
 from flask import Flask
 from flask import g
@@ -93,6 +94,7 @@ def create_app() -> Flask:
         from app.assess.routes import assess_bp
 
         flask_app.register_error_handler(404, not_found)
+        flask_app.register_error_handler(403, forbidden)
         flask_app.register_error_handler(500, internal_server_error)
         flask_app.register_blueprint(default_bp)
         flask_app.register_blueprint(assess_bp)

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -29,6 +29,15 @@ def not_found(error):
     return render_template("404.html"), 404
 
 
+@assess_bp.errorhandler(403)
+@default_bp.errorhandler(403)
+def forbidden(error):
+    error_message = f"Encountered 403: {error}"
+    stack_trace = traceback.format_exc()
+    current_app.logger.info(f"{error_message}\n{stack_trace}")
+    return render_template("403.html"), 403
+
+
 @assess_bp.errorhandler(500)
 @default_bp.errorhandler(500)
 @assess_bp.errorhandler(Exception)

--- a/app/templates/403.html
+++ b/app/templates/403.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block pageTitle %}Access Denied – {{ service_title }}{% endblock pageTitle %}
+
+{% block content %}
+    {# djlint:off #}</div>{# djlint:on #}
+    <div class="fsd-login-banner-background">
+    </div>
+    <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-xl">Access Denied</h1>
+                <p class="govuk-body">You do not have permission to access this page.</p>
+                <a href="{{ url_for('default_bp.get_help') }}"
+                   class="govuk-link govuk-link--no-underline govuk-!-margin-right-5">
+                    Get help
+                </a>
+            </div>
+        </div>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
- Add page for 403 forbidden, since it's now a common use case
- If someone without a Wales role is linked a Wales application, they may see a 403, for example
- Also if someone without a COF role is linked a COF application, they may see a 403