### PR TITLE
Makes sure valid team_name is available before rendering

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -37,7 +37,7 @@
                                     <p>Assessments</p>
                                 </div>
                                 {% for team in team_flag_stats %}
-                                {% if team.raised > 0 %}
+                                {% if team.raised > 0 and team.team_name %}
                                 <div class="lead-dashboard-stat">
                                     <p id="lead-dashboard-stat-assessments-total">{{ team.raised }}</p>
                                     <p>Total flagged for {{ team.team_name }}</p>


### PR DESCRIPTION
FS-3233: Flag application COF - Applications with no allocation team assigned displays separate metrics


### Change description
Fixed bug where old data, so applications that were flagged without a team allocation, would render a stats box with the team name reading as None. Now only renders if team_name is truthy
