### PR TITLE
FS-3162 Fix for the org type question

### DIFF
--- a/app/assess/models/ui/applicants_response.py
+++ b/app/assess/models/ui/applicants_response.py
@@ -541,7 +541,7 @@ def _convert_checkbox_items(
                 # The if in this statement has been added because the answer value for ChXWIQ is different than the display value.
                 # We should change the form in future versions
                 "question": remove_dashes_underscores_capitalize(answer)
-                if (item["field_id"] != "ChXWIQ" and answer == "none")
+                if (item["field_id"] != "ChXWIQ" and answer != "none")
                 else "None of these",
                 "field_type": item.get("field_type"),
                 "field_id": item["field_id"],

--- a/app/assess/models/ui/applicants_response.py
+++ b/app/assess/models/ui/applicants_response.py
@@ -538,7 +538,11 @@ def _convert_checkbox_items(
         text_items.append(text_item)
         text_items.extend(
             {
-                "question": remove_dashes_underscores_capitalize(answer),
+                # The if in this statement has been added because the answer value for ChXWIQ is different than the display value.
+                # We should change the form in future versions
+                "question": remove_dashes_underscores_capitalize(answer)
+                if (item["field_id"] != "ChXWIQ" and answer == "none")
+                else "None of these",
                 "field_type": item.get("field_type"),
                 "field_id": item["field_id"],
                 "answer": "Yes",


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3162

### Change description
Adding a fix for the how is you organisation classified. Also added comment to explain why the if is there.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Go to the organisation type section of an application that has the answer none selected. You should now see, Non of these as the answer


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/7bc63a2f-93ae-4884-8228-d6d0f9e9321b)
