### PR TITLE
Display 'N/A' when fullname not available in flagging

### DIFF
--- a/app/assess/templates/macros/assessment_flag.html
+++ b/app/assess/templates/macros/assessment_flag.html
@@ -16,7 +16,7 @@
         {# TODO: Notification is hardcoded. Change it once notification is implemented #}
         <h2>Notification sent</h2>
         <p>No</p><br>
-        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
+        <p class="govuk-body-s">{{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | utc_to_bst }}</p>
         {% if g.access_controller.is_lead_assessor %}
             <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.resolve_flag',application_id=application_id)}}?flag_id={{ flag.id }}">Resolve flag</a></p>
@@ -36,7 +36,7 @@
             {% endif %}
         {% endfor %}
         <br>
-        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
+        <p class="govuk-body-s">{{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.date_created | utc_to_bst }}</p>
         {% if g.access_controller.is_lead_assessor %}
             <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assess_bp.continue_assessment',application_id=application_id)}}?flag_id={{ flag.id }}">Remove flag and continue assessment</a></p>
@@ -64,7 +64,7 @@
             {% endif %}
         {% endif %}
         <br>
-        <p class="govuk-body-s">{{ user_info["full_name"] }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
+        <p class="govuk-body-s">{{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}</p>
         <p class="govuk-body-s">{{ flag.updates[-1]["date_created"] | utc_to_bst }}</p>
     </div>
 {% endmacro %}

--- a/app/assess/templates/macros/flag_history.html
+++ b/app/assess/templates/macros/flag_history.html
@@ -46,7 +46,8 @@
 
         {% endset %}
 
-        {% set username_date = '('+ accounts_list[data['user_id']]['full_name'] + ')<br>'+ data['date_created'] | utc_to_bst %}
+        {% set user_full_name = accounts_list[data['user_id']]['full_name'] or 'N/A' %}
+        {% set username_date = '('+ user_full_name + ')<br>'+ data['date_created'] | utc_to_bst %}
         {% set CreatedBy = username_date if data['status'].name=='RAISED' else 'N/A' %}
         {% set ResolvedBy = username_date if data['status'].name!='RAISED' else 'N/A' %}
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3240

Fixed the below sentry error
https://funding-service-design-team-dl.sentry.io/issues/4325904007/?alert_rule_id=13274838&alert_type=issue&project=4504418515550208&referrer=slack

### Description
Display 'N/A' when fullname not available in user accounts