### PR TITLE
BAU: Fix red herring, check .ok vs 200 only

### DIFF
--- a/app/assess/data.py
+++ b/app/assess/data.py
@@ -165,7 +165,7 @@ def get_associated_tags_for_application(application_id) -> List[Tag]:
         return None
 
 
-def update_associated_tags(application_id, tags):
+def update_associated_tags(application_id, tags) -> bool:
     endpoint = Config.ASSESSMENT_ASSOCIATE_TAGS_ENDPOINT.format(
         application_id=application_id
     )
@@ -179,13 +179,12 @@ def update_associated_tags(application_id, tags):
     )
     response = requests.put(endpoint, json=payload)
 
-    if response.status_code == 200:
-        return True
-    else:
+    was_successful = response.ok
+    if not was_successful:
         current_app.logger.error(
             f"Update associated tags failed, code: {response.status_code}."
         )
-        return False
+    return was_successful
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -225,7 +225,7 @@ def test_update_associated_tag_returns_True(flask_test_client):
 
     with mock.patch("requests.put") as mock_put:
         mock_response = mock.Mock()
-        mock_response.status_code = 200
+        mock_response.ok = True
         mock_put.return_value = mock_response
 
         new_tags = [


### PR DESCRIPTION
- Sometimes the endpoint returns 204, so we should check `.ok` vs only `200`

https://www.geeksforgeeks.org/response-ok-python-requests/
https://communities-govuk.slack.com/archives/C02PHBER287/p1689941384490099