### PR TITLE
Fs-3021 dont display flag button in scoring page

### DIFF
--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -306,7 +306,7 @@ def score(
         comments=theme_matched_comments,
         flag_status=flag_status,
         assessment_status=assessment_status,
-        is_flaggable=is_flaggable(flag_status),
+        is_flaggable=False,  # Flag button is disabled in sub-criteria page
     )
 
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3021

## Description
Disable flag button in sub-criteria page

## Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/ebcab7dc-c581-49cf-8539-d0837fc3f45a)
