### PR TITLE
text fix

### DIFF
--- a/app/assess/forms/tags.py
+++ b/app/assess/forms/tags.py
@@ -1,6 +1,5 @@
 from config import Config
 from flask_wtf import FlaskForm
-from wtforms import BooleanField
 from wtforms import RadioField
 from wtforms import SelectMultipleField
 from wtforms import TextAreaField
@@ -42,10 +41,7 @@ class EditTagForm(FlaskForm):
 
 
 class DeactivateTagForm(FlaskForm):
-    deactivate = BooleanField(
-        "boolean",
-        validators=[InputRequired()],
-    )
+    pass
 
 
 class ReactivateTagForm(FlaskForm):

--- a/app/assess/tag_routes.py
+++ b/app/assess/tag_routes.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Dict
 
 from app.assess.auth.validation import check_access_application_id
@@ -100,7 +101,7 @@ def get_fund_round(fund_id, round_id) -> Dict:
 def load_fund_round_tags(fund_id, round_id):
     fund_round = get_fund_round(fund_id, round_id)
     search_params, show_clear_filters = match_search_params(
-        search_params_tag, request.args
+        copy.deepcopy(search_params_tag), request.args
     )
     tags = get_tags_for_fund_round(fund_id, round_id, search_params)
     tag_types = get_tag_types()
@@ -147,7 +148,7 @@ def create_tag(fund_id, round_id):
         if not tag_created:
             flash(FLAG_ERROR_MESSAGE)
 
-        if go_back:
+        if go_back and tag_created:
             return redirect(
                 url_for(
                     "tag_bp.load_fund_round_tags",

--- a/app/assess/templates/deactivate_tag.html
+++ b/app/assess/templates/deactivate_tag.html
@@ -2,7 +2,7 @@
 {% from "macros/tag_header.html" import tag_header %}
 
 {% block header %}
-{{ tag_header("manage tags", url_for("tag_bp.load_fund_round_tags", fund_id=fund_round["fund_id"], round_id=fund_round["round_id"]), fund_round, sso_logout_url) }}
+{{ tag_header("edit_tag", url_for("tag_bp.edit_tag", fund_id=fund_round["fund_id"], round_id=fund_round["round_id"], tag_id=tag.id), fund_round, sso_logout_url) }}
 {% endblock header %}
 
 {% block content %}
@@ -19,34 +19,16 @@
       </div>
   {% endfor %}
     <p class="govuk-body-l govuk-!-font-weight-bold">Are you sure you want to deactivate this tag?</p>
-    <p class="govuk-body govuk-!-margin-bottom-8">This action will remove the tag from all
+    <p class="govuk-body">This will remove the tag from {{tag.tag_association_count}}
       {% trans count=tag.tag_association_count%}
-        {{ count }} application
+        assessment
       {% pluralize %}
-        {{ count }} applications
-      {% endtrans %}{{tag.tag_association_count}}
-      this tag is being used by and cannot be undone.</p>
+        assessments
+      {% endtrans %}
+      where this tag is applied.</p>
+      <p class="govuk-body govuk-!-margin-bottom-8">You can undo this by reactivating the tag.</p>
     <form method="post">
       {{ form.csrf_token }}
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="deactivate-hint">
-          <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="deactivate" name="deactivate" type="checkbox"
-                value="{{tag.id}}">
-              <label class="govuk-label govuk-checkboxes__label" for="deactivate">
-                I understand this tag will be removed from
-                {% trans count=tag.tag_association_count%}
-                  {{ count }} application,
-                {% pluralize %}
-                  all {{ count }} applications,
-                {% endtrans %}
-                 and this <b>cannot</b> be undone.
-              </label>
-            </div>
-          </div>
-        </fieldset>
-      </div>
 
 
       <div class="govuk-button-group">

--- a/app/assess/templates/reactivate_tag.html
+++ b/app/assess/templates/reactivate_tag.html
@@ -19,7 +19,7 @@
         </div>
     {% endfor %}
     <p class="govuk-body-l govuk-!-font-weight-bold">Are you sure you want to reactivate this tag?</p>
-    <p class="govuk-body govuk-!-margin-bottom-8">This action will not restore the tag in previously selected applications.</p>
+    <p class="govuk-body govuk-!-margin-bottom-8">Once reactivated, this tag will be reapplied to all assessments it was previously applied to.</p>
     <form method="post">
       {{ form.csrf_token }}
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -416,34 +416,6 @@ def test_get_deactivate_route(
         "get_rounds_path": "app.assess.tag_routes.get_round",
     }
 )
-def test_post_deactivate_existing_tag_without_checkbox_returns_error(
-    client_with_valid_session,
-    mock_get_funds,
-    mock_get_fund,
-    mock_get_tag_types,
-    mock_get_round,
-    mock_get_tag_for_fund_round,
-):
-    data = {}
-    with mock.patch(
-        "app.assess.tag_routes.update_tags",
-        return_value=True,
-    ):
-        response = client_with_valid_session.post(
-            f"/assess/tags/deactivate/{test_fund_id}/{test_round_id}/{mock_get_tag_for_fund_round.id}",
-            data=data,
-        )
-
-    assert response.status_code == 200
-    assert "Tag not deactivated." in response.text
-    assert "Yes, deactivate tag" in response.text
-
-
-@pytest.mark.mock_parameters(
-    {
-        "get_rounds_path": "app.assess.tag_routes.get_round",
-    }
-)
 def test_post_deactivate_existing_tag_with_checkbox_redirects(
     client_with_valid_session,
     mock_get_funds,


### PR DESCRIPTION
- Counter displaying twice in Deactivate tag page
- Creating a new tag with the same tag name as the deactivate one doesn't generate error message on the page but redirects the assessors back to the Manage tags page
- Clear search in Manage tags page doesn't reset filters properly
- Error message displaying in Reactivate tags page
- Deactivate tag page back link doesn't return to Edit tags page
