### PR TITLE
allowing assessors to set tags

### DIFF
--- a/app/assess/templates/assessor_tasklist.html
+++ b/app/assess/templates/assessor_tasklist.html
@@ -41,7 +41,7 @@
 {% block content %}
 <div class="govuk-grid-row">
 {% if toggle_dict.get("TAGGING") %}
-    {% if g.access_controller.is_lead_assessor %}
+    {% if g.access_controller.is_assessor %}
         <div class="govuk-grid-column-full">
             {% if tags %}
                 {% for t in tags %}

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -39,7 +39,7 @@ class DevelopmentConfig(DefaultConfig):
             "COF_SCOTLAND",
             "COF_WALES",
             "COF_NORTHERNIRELAND",
-            "NSTF_LEAD_ASSESSOR",
+            # "NSTF_LEAD_ASSESSOR",
             "NSTF_ASSESSOR",
             "NSTF_COMMENTER",
         ],


### PR DESCRIPTION
Ticket ref pending - fixing bug where general assessors (not leads) are unable to see the change tags/add tags button.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
User does not have lead assessor for NSTF, but can see the change tags link now.
<img width="657" alt="Screenshot 2023-08-03 at 07 05 30" src="https://github.com/communitiesuk/funding-service-design-assessment/assets/1729216/f1c778c6-c3f9-421e-98af-4d7aa4f9e14f">

