### PR TITLE
Improve performance of assessment_dashboard

### DIFF
--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -36,6 +36,23 @@ flagged_app = {
             ],
         },
     ],
+    "tag_associations": [
+        {
+            "associated": True,
+            "id": "e908512a-25ef-4ec8-9850-b5a9c867992f",
+            "user_id": test_user_id_lead_assessor,
+            "tag": {
+                "active": True,
+                "creator_user_id": test_user_id_lead_assessor,
+                "id": "52ea161d-8593-4943-8676-baae283cd979",
+                "value": "Tag one red",
+                "tag_type": {
+                    "id": "5e7ecf78-9239-498a-9086-008043230a69",
+                    "purpose": "NEGATIVE",
+                },
+            },
+        }
+    ],
     "qa_complete": [],
     "is_qa_complete": False,
     "criteria_sub_criteria_name": "test_sub_criteria",
@@ -85,6 +102,23 @@ resolved_app = {
             ],
         },
     ],
+    "tag_associations": [
+        {
+            "associated": True,
+            "id": "f908512a-25ef-4ec8-9850-b5a9c867992f",
+            "user_id": test_user_id_lead_assessor,
+            "tag": {
+                "active": True,
+                "creator_user_id": test_user_id_lead_assessor,
+                "id": "62ea161d-8593-4943-8676-baae283cd979",
+                "value": "Tag one red",
+                "tag_type": {
+                    "id": "7e7ecf78-9239-498a-9086-008043230a69",
+                    "purpose": "NEGATIVE",
+                },
+            },
+        }
+    ],
     "qa_complete": [],
     "is_qa_complete": False,
     "criteria_sub_criteria_name": "test_sub_criteria",
@@ -127,6 +161,23 @@ stopped_app = {
             ],
         },
     ],
+    "tag_associations": [
+        {
+            "associated": True,
+            "id": "g908512a-25ef-4ec8-9850-b5a9c867992f",
+            "user_id": test_user_id_lead_assessor,
+            "tag": {
+                "active": True,
+                "creator_user_id": test_user_id_lead_assessor,
+                "id": "72ea161d-8593-4943-8676-baae283cd979",
+                "value": "Tag one red",
+                "tag_type": {
+                    "id": "7e7ecf78-9239-498a-9086-008043230a69",
+                    "purpose": "NEGATIVE",
+                },
+            },
+        }
+    ],
     "qa_complete": [],
     "is_qa_complete": False,
 }
@@ -156,6 +207,23 @@ flagged_qa_completed_app = {
                 }
             ],
         },
+    ],
+    "tag_associations": [
+        {
+            "associated": True,
+            "id": "h908512a-25ef-4ec8-9850-b5a9c867992f",
+            "user_id": test_user_id_lead_assessor,
+            "tag": {
+                "active": True,
+                "creator_user_id": test_user_id_lead_assessor,
+                "id": "82ea161d-8593-4943-8676-baae283cd979",
+                "value": "Tag one red",
+                "tag_type": {
+                    "id": "8e7ecf78-9239-498a-9086-008043230a69",
+                    "purpose": "NEGATIVE",
+                },
+            },
+        }
     ],
     "qa_complete": [
         {
@@ -209,6 +277,7 @@ mock_api_results = {
             "application_id": flagged_qa_completed_app_id,
             "asset_type": "gallery",
             "flags_v2": flagged_qa_completed_app["flags_v2"],
+            "tag_associations": flagged_qa_completed_app["tag_associations"],
             "qa_complete": flagged_qa_completed_app["qa_complete"],
             "funding_amount_requested": test_funding_requested + 2000,
             "is_qa_complete": True,
@@ -232,6 +301,7 @@ mock_api_results = {
             "application_id": stopped_app_id,
             "asset_type": stopped_app["asset_type"],
             "flags_v2": stopped_app["flags_v2"],
+            "tag_associations": stopped_app["tag_associations"],
             "qa_complete": stopped_app["qa_complete"],
             "funding_amount_requested": test_funding_requested + 1000,
             "is_qa_complete": False,
@@ -255,6 +325,7 @@ mock_api_results = {
             "application_id": resolved_app_id,
             "asset_type": "gallery",
             "flags_v2": resolved_app["flags_v2"],
+            "tag_associations": resolved_app["tag_associations"],
             "qa_complete": resolved_app["qa_complete"],
             "funding_amount_requested": test_funding_requested,
             "is_qa_complete": False,
@@ -280,6 +351,7 @@ mock_api_results = {
             "application_id": stopped_app_id,
             "asset_type": stopped_app["asset_type"],
             "flags_v2": stopped_app["flags_v2"],
+            "tag_associations": stopped_app["tag_associations"],
             "qa_complete": stopped_app["qa_complete"],
             "funding_amount_requested": test_funding_requested,
             "is_qa_complete": False,
@@ -570,6 +642,7 @@ mock_api_results = {
         "application_id": stopped_app_id,
         "asset_type": stopped_app["asset_type"],
         "flags_v2": stopped_app["flags_v2"],
+        "tag_associations": stopped_app["tag_associations"],
         "qa_complete": stopped_app["qa_complete"],
         "funding_amount_requested": test_funding_requested + 1000,
         "is_qa_complete": False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -706,7 +706,6 @@ def mock_get_associated_tags_for_application(mocker):
     for function_module_path in [
         "app.assess.routes.get_associated_tags_for_application",
         "app.assess.tag_routes.get_associated_tags_for_application",
-        "app.assess.helpers.get_associated_tags_for_application",
         "app.assess.data.get_associated_tags_for_application",
     ]:
         mocker.patch(
@@ -775,5 +774,35 @@ def mock_get_tag_types(mocker):
                     description="Tag type 1 description",
                 )
             ],
+        )
+    yield
+
+
+@pytest.fixture(scope="function")
+def mock_get_tag_map_and_tag_options(mocker):
+    for function_module_path in [
+        "app.assess.routes.get_tag_map_and_tag_options",
+    ]:
+        mocker.patch(
+            function_module_path,
+            return_value=(
+                [
+                    AssociatedTag(
+                        application_id="75dabe60-ae89-4a47-9263-d35e010b6c66",
+                        associated=True,
+                        purpose="NEGATIVE",
+                        tag_id="75f4296f-502b-4293-82a8-b828e678dd9e",
+                        user_id="65f4296f-502b-4293-82a8-b828e678dd9e",
+                        value="Tag one red",
+                    )
+                ],
+                [
+                    TagType(
+                        id="tag_type_1",
+                        purpose="POSITIVE",
+                        description="Tag type 1 description",
+                    )
+                ],
+            ),
         )
     yield

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -162,7 +162,6 @@ class TestRoutes:
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
         mock_get_application_metadata,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -221,7 +220,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -295,7 +293,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -340,7 +337,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -385,7 +381,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -431,7 +426,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -495,7 +489,6 @@ class TestRoutes:
         sort_column,
         sort_order,
         column_id,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):
@@ -1158,7 +1151,6 @@ class TestRoutes:
         mock_get_assessment_stats,
         mock_get_teams_flag_stats,
         mock_get_assessment_progress,
-        mock_get_associated_tags_for_application,
         mock_get_active_tags_for_fund_round,
         mock_get_tag_types,
     ):


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3269

## Description
Current implementation makes multiple API calls to tagging endpoint for every application which caused the performance issues on assessment dashboard. 
- Tags are now retrieved with single API `application overviews endpoint`(no need to make separate API call to fetch tags) to improve the performance
- updated the mock data & unit tests

Also check the PR https://github.com/communitiesuk/funding-service-design-assessment-store/pull/261

## Screenshots of UI changes (if applicable)
### Before (3.94 seconds to load 50 applications)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/127315890/4461bee2-6a91-4dd1-b717-c11a65560b4d)
### After (1.73 seconds to load 50 applications)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/127315890/1735c2d1-0eb5-421f-a8a9-a54e520fc826)

