### PR TITLE
FS-3235: Format answers for csv/pdf & expose "pdf" on UI

### DIFF
--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -27,6 +27,7 @@ from flask import render_template
 from flask import request
 from flask import Response
 from flask import url_for
+from fsd_utils.mapping.application.application_utils import format_answer
 from fsd_utils.mapping.application.application_utils import simplify_title
 
 
@@ -265,7 +266,7 @@ def generate_csv_of_application(q_and_a: dict, fund: Fund, application_json):
             if not answers:
                 answers = "Not provided"
 
-            writer.writerow([section_title, questions, answers])
+            writer.writerow([section_title, questions, format_answer(answers)])
     return output.getvalue()
 
 

--- a/app/assess/models/file_factory.py
+++ b/app/assess/models/file_factory.py
@@ -47,7 +47,7 @@ def _generate_pdf_of_application(args: ApplicationFileRepresentationArgs):
         )
 
 
-_FILE_GENERATORS = {
+FILE_GENERATORS = {
     "txt": _generate_text_of_application,
     "csv": _generate_csv_of_application,
     "pdf": _generate_pdf_of_application,
@@ -81,7 +81,7 @@ def generate_file_content(
         >>> generate_file_content(args, 'txt')
         [Generates and returns the text representation of the application]
     """
-    if file_generator := _FILE_GENERATORS.get(file_type):
+    if file_generator := FILE_GENERATORS.get(file_type):
         return file_generator(args)
 
     abort(404)

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -50,6 +50,7 @@ from app.assess.helpers import match_search_params
 from app.assess.helpers import resolve_application
 from app.assess.helpers import set_application_status_in_overview
 from app.assess.models.file_factory import ApplicationFileRepresentationArgs
+from app.assess.models.file_factory import FILE_GENERATORS
 from app.assess.models.file_factory import generate_file_content
 from app.assess.models.flag_teams import TeamsFlagData
 from app.assess.models.flag_v2 import FlagTypeV2
@@ -650,31 +651,25 @@ def generate_doc_list_for_download(application_id):
         short_id=short_id,
         application_json=application_json,
     )
-    application_answers_txt = (
-        "Application answers, text file",
-        url_for(
-            "assess_bp.download_application_answers",
-            application_id=application_id,
-            short_id=short_id,
-            file_type="txt",
-        ),
-    )
-    application_answers_pdf = (
-        "Application answers, pdf file",
-        url_for(
-            "assess_bp.download_application_answers",
-            application_id=application_id,
-            short_id=short_id,
-            file_type="pdf",
-        ),
-    )
+
+    file_links = [
+        (
+            f"Application answers, {file_type} file",
+            url_for(
+                "assess_bp.download_application_answers",
+                application_id=application_id,
+                short_id=short_id,
+                file_type=file_type,
+            ),
+        )
+        for file_type in FILE_GENERATORS.keys()
+    ]
 
     return render_template(
         "contract_downloads.html",
         application_id=application_id,
         state=state,
-        application_answers_txt=application_answers_txt,
-        application_answers_pdf=application_answers_pdf,
+        file_links=file_links,
         supporting_evidence=supporting_evidence,
         assessment_status=assessment_status,
         flag_status=flag_status,

--- a/app/assess/routes.py
+++ b/app/assess/routes.py
@@ -650,8 +650,8 @@ def generate_doc_list_for_download(application_id):
         short_id=short_id,
         application_json=application_json,
     )
-    application_answers = (
-        "Application answers",
+    application_answers_txt = (
+        "Application answers, text file",
         url_for(
             "assess_bp.download_application_answers",
             application_id=application_id,
@@ -659,12 +659,22 @@ def generate_doc_list_for_download(application_id):
             file_type="txt",
         ),
     )
+    application_answers_pdf = (
+        "Application answers, pdf file",
+        url_for(
+            "assess_bp.download_application_answers",
+            application_id=application_id,
+            short_id=short_id,
+            file_type="pdf",
+        ),
+    )
 
     return render_template(
         "contract_downloads.html",
         application_id=application_id,
         state=state,
-        application_answers=application_answers,
+        application_answers_txt=application_answers_txt,
+        application_answers_pdf=application_answers_pdf,
         supporting_evidence=supporting_evidence,
         assessment_status=assessment_status,
         flag_status=flag_status,

--- a/app/assess/templates/contract_downloads.html
+++ b/app/assess/templates/contract_downloads.html
@@ -13,7 +13,8 @@
 
             <h2 class="govuk-heading-l govuk-!-margin-top-4">Export application data</h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link" href="{{ application_answers[1] }}">{{ application_answers[0] }}</a></li>
+                <li><a class="govuk-link" href="{{ application_answers_txt[1] }}">{{ application_answers_txt[0] }}</a></li>
+                <li><a class="govuk-link" href="{{ application_answers_pdf[1] }}">{{ application_answers_pdf[0] }}</a></li>
             </ul>
             <h3 class="govuk-heading-l govuk-!-margin-top-4">Supporting evidence</h3>
             <ul class="govuk-list">

--- a/app/assess/templates/contract_downloads.html
+++ b/app/assess/templates/contract_downloads.html
@@ -13,8 +13,9 @@
 
             <h2 class="govuk-heading-l govuk-!-margin-top-4">Export application data</h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link" href="{{ application_answers_txt[1] }}">{{ application_answers_txt[0] }}</a></li>
-                <li><a class="govuk-link" href="{{ application_answers_pdf[1] }}">{{ application_answers_pdf[0] }}</a></li>
+                {% for text, href in file_links %}
+                <li><a class="govuk-link" href="{{ href }}">{{ text }}</a></li>
+                {% endfor %}
             </ul>
             <h3 class="govuk-heading-l govuk-!-margin-top-4">Supporting evidence</h3>
             <ul class="govuk-list">

--- a/app/pdf/full_application.py
+++ b/app/pdf/full_application.py
@@ -3,6 +3,7 @@ from functools import partial
 
 from app.assess.views.filters import format_date
 from app.pdf.pdf_generator import generate_pdf
+from fsd_utils.mapping.application.application_utils import format_answer
 
 
 @dataclass
@@ -53,7 +54,7 @@ class FullApplicationPdfContext:
                     questions_and_answers=[
                         QuestionAndAnswer(
                             question=i["question"],
-                            answer=i.get("answer"),
+                            answer=format_answer(i.get("answer")),
                             number="",
                         )
                         for i in args.all_uploaded_documents


### PR DESCRIPTION
- Adds all file types to the UI on the export page
- Uses existing `format_answers` function on answers on csv/pdf
