### PR TITLE
FS-3168: Add JavaScript for tabs

### DIFF
--- a/app/static/src/js/helpers.js
+++ b/app/static/src/js/helpers.js
@@ -45,3 +45,23 @@ if (showTagsElement) {
         });
     });
 }
+
+const tabs = document.querySelectorAll('[id^="tab"]');
+const tabAnchors = document.querySelectorAll('.govuk-tabs__tab');
+Array.from(tabAnchors).forEach(tabAnchor => {
+    tabAnchor.addEventListener('click', (tabAnchorElement) => {
+        const hash = tabAnchorElement.target.hash;
+        if (hash) {
+            Array.from(tabs).forEach((tab) => {
+                tab.classList.add('govuk-tabs__panel--hidden');
+            });
+            Array.from(tabAnchors).forEach((tabA) => {
+               tabA.parentElement.classList.remove('govuk-tabs__list-item--selected')
+            });
+
+            const activeTab = document.getElementById(hash.replace('#', ''));
+            activeTab.classList.remove('govuk-tabs__panel--hidden');
+            tabAnchorElement.target.parentElement.classList.add('govuk-tabs__list-item--selected');
+        }
+    });
+})


### PR DESCRIPTION
### Change description

- Add some client side JavaScript to fix the tabs for flag history
- Ideally we would upgrade `govuk-frontend-jinja==2.7.0` but that doesn't seem to fix it...

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines