### PR TITLE
bug-fix/FS-3330-assessment-status-for-resolve-flag-and-continue-assessment-page

### DIFF
--- a/app/assess/helpers.py
+++ b/app/assess/helpers.py
@@ -205,7 +205,7 @@ def resolve_application(
         state.workflow_status
         if state
         else sub_criteria_banner_state.workflow_status,
-        flags_list,
+        state.is_qa_complete,
     )
     flag_status = determine_flag_status(flags_list)
 


### PR DESCRIPTION
This pull request resolves a bug that caused the incorrect assessment_status to be displayed on the resolve_flag.html and continue-assessment.html pages