### PR TITLE
bug-fix/FS-3333-margin-issue-with-assessment-dashboard

### DIFF
--- a/app/assess/templates/assessor_dashboard.html
+++ b/app/assess/templates/assessor_dashboard.html
@@ -19,9 +19,9 @@
         {{ logout_partial(sso_logout_url) }}
         </div>
     </nav>
-</div>
+
     <div class="fsd-banner-background">
-        <div class="fsd-dashboard-width-container">
+        <div class="govuk-width-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <div class="govuk-grid-column-two-thirds">
@@ -58,9 +58,9 @@
 {% endblock header %}
 {% block content %}
 {#    CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
-    </div>
-    <div class="fsd-dashboard-width-container">
-    <section class="govuk-grid-column-full">
+
+<div class="govuk-grid-row">
+    <section class="govuk-width-container govuk-grid-column-full">
         {% if round_details.fund_short_name.upper() == 'NSTF' %}
             {{ application_overviews_table_nstf.render(
                 application_overviews,


### PR DESCRIPTION
This tiny PR fixes the margin issue on the assessment dashboard page 


### Screenshots 

![Screenshot 2023-08-14 at 15 37 25](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/ca3e674b-8a77-4e71-b57c-9ce4e82dcb8b)
![Screenshot 2023-08-14 at 15 37 13](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/e2895e04-10cd-45e6-bbfb-865ab713762e)

