### PR TITLE
BAU: Add version/cache-busting to javascript/css

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -1,6 +1,14 @@
 """Compile static assets."""
+import time
+
 from flask_assets import Bundle
 from webassets.exceptions import BuildError
+
+
+# we use the current time to cache-bust
+# so users don't need to clear their cache manually on js/css changes
+def asset_version():
+    return int(time.time())
 
 
 def compile_static_assets(assets, flask_app):
@@ -32,6 +40,7 @@ def compile_static_assets(assets, flask_app):
         filters="pyscss,cssmin",
         output="css/main.min.css",
         extra={"rel": "stylesheet/css"},
+        version=asset_version(),
     )
 
     default_js_bundle = Bundle(
@@ -41,6 +50,7 @@ def compile_static_assets(assets, flask_app):
         "../src/js/components/*/*.js",
         filters="jsmin",
         output="js/main.min.js",
+        version=asset_version(),
     )
 
     assets.register("default_styles", default_style_bundle)

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -3,8 +3,12 @@
 <meta name="author" content="{{ service_meta_author }}">
 <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-4.7.0.min.css') }}" /><!--<![endif]-->
 <!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-ie8-4.7.0.min.css') }}" /><![endif]-->
-<!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/main.min.css') }}" /><!--<![endif]-->
+{% assets "default_styles" %}
+    <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}"><!--<![endif]-->
+{% endassets %}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static',filename='styles/landing.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static',filename='styles/govuk-overrides.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static',filename='styles/comments.css') }}">
-<script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/main.min.js') }}" defer></script>
+{% assets "main_js" %}
+    <script nonce="{{ csp_nonce() }}" type="text/javascript" src="{{ ASSET_URL }}" defer></script>
+{% endassets %}


### PR DESCRIPTION
### Change description

- Start using the template tags provided by Flask-Assets rather than hardcoded urls
- Version css/javascript bundles based on the current time, meaning each app restart will cache-bust

### How to test

- Pull this branch, observe the css/javascript bundles in your `<head>` tags on any page
- Make a change to javascript/css files & ensure app has restarted (might not auto-refresh on js/css changes)
- Observe your changes to the javascript/css depending on what you changed, or view the new unique url in the `<head>` tags