### PR TITLE
FS-2319: Accessibility fixes

### DIFF
--- a/app/blueprints/assessments/templates/assessor_dashboard.html
+++ b/app/blueprints/assessments/templates/assessor_dashboard.html
@@ -47,8 +47,8 @@
                             </div>
                         {% endif %}
                         <h2 class="govuk-heading-l fsd-banner-content"> {% if is_active_status %}All active assessments{% else %}All closed assessments{% endif %}</h2>
-                        <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding"><strong>Fund: </strong>{{ round_details["fund_name"] }}</h3>
-                        <h3 class="govuk-body-l fsd-banner-content"><strong>Round: </strong>{{ round_details["round_title"] }}</h3>
+                        <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding"><strong>Fund: </strong>{{ round_details["fund_name"] }}</p>
+                        <p class="govuk-body-l fsd-banner-content"><strong>Round: </strong>{{ round_details["round_title"] }}</p>
                     </div>
             </div>
             </div>

--- a/app/blueprints/assessments/templates/macros/section_element.html
+++ b/app/blueprints/assessments/templates/macros/section_element.html
@@ -3,36 +3,26 @@
     {% if name != "Unscored" %}
         <h2 class="govuk-heading-l govuk-!-margin-top-4">{{ name }}</h2>
     {% endif %}
-    {% set rows = [] %}
-    {% for sub_criteria in sub_criterias %}
-        {% set _ = rows.append([
-            {
-                'html': '<a class="govuk-link" data-qa="sub_criteria_name" href="{}">{}</a>'.format(
-                    url_for(
-                        'assessment_bp.display_sub_criteria',
-                         application_id=application_id,
-                         sub_criteria_id=sub_criteria.id
-                    ),
-                    sub_criteria.name
-                )
-            }
-        ]) %}
-    {% endfor %}
-    {% if name == "Declarations" %}
-        {{ govukTable({
-            "caption": "Review against legal and policy requirements.",
-            "firstCellIsHeader":false,
-            "head": [[{ "text": "" }]],
-            "captionClasses": "govuk-body govuk-!-text-align-left govuk-!-font-weight-regular govuk-!-margin-bottom-4",
-            "rows": rows,
-        }) }}
-    {% else %}
-        {{ govukTable({
-            "caption": "Use for due diligence checks." if show_caption else "",
-            "firstCellIsHeader":false,
-            "head": [[{ "text": "" }]],
-            "captionClasses": "govuk-body govuk-!-text-align-left govuk-!-font-weight-regular govuk-!-margin-bottom-4",
-            "rows": rows,
-        }) }}
-    {% endif %}
+
+    {% set caption = "Review against legal and policy requirements." if name == "Declarations" else
+                 ("Use for due diligence checks." if show_caption else "") %}
+    <p class="govuk-body govuk-!-text-align-left govuk-!-font-weight-regular govuk-!-margin-bottom-4">
+        {{ caption }}
+    </p>
+    <dl class="govuk-summary-list">
+        {% for sub_criteria in sub_criterias %}
+            {% set sub_criteria_url = url_for(
+                'assessment_bp.display_sub_criteria',
+                application_id=application_id,
+                sub_criteria_id=sub_criteria.id
+            ) %}
+
+            <div class="govuk-summary-list__row">
+                <dd class="govuk-summary-list__actions govuk-!-text-align-left">
+                    <a class="govuk-link" data-qa="sub_criteria_name" href="{{ sub_criteria_url }}">{{ sub_criteria.name }}</a>
+                </dd>
+            </div>
+        {% endfor %}
+    </dl>
+
 {% endmacro %}

--- a/app/static/src/styles/govuk-overrides.css
+++ b/app/static/src/styles/govuk-overrides.css
@@ -395,3 +395,7 @@ body .govuk-button--warning:hover {
 a.govuk-link.deactivate {
     color: #d4351c;
 }
+
+.govuk-summary-list:first-of-type {
+    border-top: 1px solid #b1b4b6;
+}

--- a/app/templates/macros/banner_summary.html
+++ b/app/templates/macros/banner_summary.html
@@ -10,10 +10,10 @@
                     <p class="govuk-body-l fsd-banner-content ">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</p>
 
                     {% if g.access_controller.has_any_assessor_role %}
-                    <strong class="govuk-tag govuk-tag--grey govuk-!-margin-top-4">{{assessment_status}}</strong>
-                    {% endif %}
-                    {% if g.access_controller.has_any_assessor_role and (("Flagged" in  flag_status) or (flag_status in ["Multiple flags to resolve", "Stopped", "Flagged"])) %}
-                        <h3 class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding govuk-!-margin-top-3">{{ flag_status or "" }}</h3>
+                        <p><strong class="govuk-tag govuk-tag--grey govuk-!-margin-top-4">{{ assessment_status }}</strong>
+                        {% if "Flagged" in flag_status or flag_status in ["Multiple flags to resolve", "Stopped", "Flagged"] %}
+                            <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding govuk-!-margin-top-3">{{ flag_status or "" }}</p>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/app/templates/macros/theme/question_above_answer.jinja2
+++ b/app/templates/macros/theme/question_above_answer.jinja2
@@ -1,6 +1,6 @@
 {% macro question_above_answer(meta) %}
 
-    <h2 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h2>
+    <h4 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h4>
     <p class="govuk-body"> {{ "£{:,.2f}".format(meta.answer) if meta.answer is number else meta.answer }} </p>
 
 {% endmacro %}

--- a/app/templates/macros/theme/question_above_answer_html.jinja2
+++ b/app/templates/macros/theme/question_above_answer_html.jinja2
@@ -1,6 +1,6 @@
 {% macro question_above_answer_html(meta) %}
 
-    <h2 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h2>
+    <h4 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h4>
     <span class="govuk-body"> {{ meta.answer | safe }} </span>
 
 {% endmacro %}

--- a/app/templates/macros/theme/question_above_href_answer.jinja2
+++ b/app/templates/macros/theme/question_above_href_answer.jinja2
@@ -2,9 +2,9 @@
 
 {% macro question_above_href_answer(meta) %}
 
-    <h2 class="govuk-summary-list govuk-!-margin-bottom-4"><strong>{{ meta.question }}</strong></h2>
+    <h4 class="govuk-summary-list govuk-!-margin-bottom-4"><strong>{{ meta.question }}</strong></h4>
     {% if meta.answer_href %}
-        <h3><a class="govuk-link govuk-!-font-weight-regular" href="{{ meta.answer_href }}">{{ meta.answer }}</a></h3>
+        <a class="govuk-link govuk-!-font-weight-regular" href="{{ meta.answer_href }}">{{ meta.answer }}</a>
     {% else %}
         <p class="govuk-body">{{ meta.answer }}</p>
     {% endif %}

--- a/app/templates/macros/theme/question_above_href_answer_list.jinja2
+++ b/app/templates/macros/theme/question_above_href_answer_list.jinja2
@@ -2,14 +2,12 @@
 
 {% macro question_above_href_answer_list(meta) %}
 
-    <h2 class="govuk-summary-list govuk-!-margin-bottom-4">
-        <strong>{{ meta.question }}</strong></h2>
+    <h4 class="govuk-summary-list govuk-!-margin-bottom-4">
+        <strong>{{ meta.question }}</strong></h4>
     {% for key, href in meta.key_to_url_dict.items() %}
-        <h3>
-            <a class="govuk-link govuk-!-font-weight-regular"
-               {# we split by / and render just the filename #}
-               href="{{ href }}">{{ key.rsplit("/", 1)[-1] }}</a>
-        </h3>
+        <a class="govuk-link govuk-!-font-weight-regular"
+           {# we split by / and render just the filename #}
+           href="{{ href }}">{{ key.rsplit("/", 1)[-1] }}</a>
     {% endfor %}
     {% if not meta.key_to_url_dict %}
         <p class="govuk-body">Not provided.</p>

--- a/app/templates/macros/theme/question_heading.jinja2
+++ b/app/templates/macros/theme/question_heading.jinja2
@@ -1,3 +1,3 @@
 {% macro question_heading(meta) %}
-    <h2 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h2>
+    <h4 class="govuk-heading-s"><strong> {{ meta.question }} </strong></h4>
 {% endmacro %}

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -645,7 +645,7 @@ class TestJinjaMacros(object):
             text="Submitted",
         ), "Assessment status not found"
         assert soup.find(
-            "h3", class_="fsd-banner-content", text="Flagged"
+            "p", class_="fsd-banner-content", text="Flagged"
         ), "Flag status not found"
 
     def test_stopped_flag_macro(self, request_ctx):


### PR DESCRIPTION
### Change description

- Use list instead of table for unscored sections
- Change some heading to paragraph tags for structured hierarchy
- Change theme answers to h4 as they come after h3

Addresses pages 17-30:
- [DAC Accessibility Report WCAG 2.1 - DLUHC Community ownership fund assessment - 08-02-23 - Final.pdf](https://github.com/communitiesuk/funding-service-design-assessment/files/12550892/DAC.Accessibility.Report.WCAG.2.1.-.DLUHC.Community.ownership.fund.assessment.-.08-02-23.-.Final.1.pdf)

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
