### PR TITLE
show assessments on live round

### DIFF
--- a/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
+++ b/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
@@ -52,6 +52,11 @@
                     ],
                 })
             }}
+            {% if assessments_href %}
+                <a class="govuk-link" data-qa="dashboard_summary" href="{{ assessments_href }}">
+                    View all submitted applications
+                </a>
+            {% endif %}
         {% endif %}
         {% if assessment_stats %}
             {{ govukTable({

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -42,7 +42,9 @@ class DefaultConfig:
     DASHBOARD_ROUTE = "/assess/assessor_tool_dashboard"
 
     # Assessement settings
-    SHOW_ALL_ROUNDS = strtobool(getenv("SHOW_ALL_ROUNDS", "False"))
+    SHOW_ASSESSMENTS_LIVE_ROUNDS = strtobool(
+        getenv("SHOW_ASSESSMENTS_LIVE_ROUNDS", "False")
+    )  # Set to True to show assessments on live rounds
 
     """
     Security

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -25,7 +25,9 @@ class DevelopmentConfig(DefaultConfig):
     SSO_LOGOUT_URL = AUTHENTICATOR_HOST + "/sso/logout"
 
     DEBUG_USER_ON = True  # Set to True to use DEBUG user
-    SHOW_ALL_ROUNDS = True  # Set to True to show all rounds
+    SHOW_ASSESSMENTS_LIVE_ROUNDS = (
+        True  # Set to True to show assessments on live rounds
+    )
 
     DEBUG_USER_ROLE = "LEAD_ASSESSOR"
     DEBUG_USER = {


### PR DESCRIPTION

### Description
show submitted applications for live round in development mode config

Useful for, 
- development & testing of assessment when round is not yet opened
- exploratory tests for assessments tickets when assessment is not yet opened

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/931f2df8-8028-4ddd-8ad9-8b9fdfea678b)

