### PR TITLE
FS-3438: Add round links even when live

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -179,6 +179,7 @@ def landing():
             for rsl in round_summaries.values()
             for rs in rsl
         ),
+        show_assessments_live_rounds=Config.SHOW_ASSESSMENTS_LIVE_ROUNDS,
     )
 
 

--- a/app/blueprints/assessments/templates/assessor_tool_dashboard.html
+++ b/app/blueprints/assessments/templates/assessor_tool_dashboard.html
@@ -63,7 +63,7 @@
                             {% for chunk in summaries|batch(chunk_size) %}
                                 <div class="govuk-grid-row">
                                     {% for summary in chunk %}
-                                        {{ fund_summary(**summary.__dict__) }}
+                                        {{ fund_summary(summary, show_assessments_live_rounds) }}
                                     {% endfor %}
                                 </div>
                             {% endfor %}

--- a/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
+++ b/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
@@ -1,5 +1,22 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 
+{% macro round_links(access_controller, export_href, assessment_tracker_href) %}
+    {% if access_controller.is_lead_assessor %}
+        {% if access_controller.round_application_fields_download_available %}
+            </br>
+            </br>
+            <a class="govuk-link" href="{{ export_href }}">
+                Export applicant information
+            </a>
+        {% endif %}
+        </br>
+        </br>
+        <a class="govuk-link" href="{{ assessment_tracker_href }}">
+            Assessment Tracker Export
+        </a>
+    {% endif %}
+{% endmacro %}
+
 {% macro fund_summary(name, is_assessment_active_status, is_round_open_status, is_not_yet_open_status, fund_id, round_id, fund_name, round_name, assessment_stats, live_round_stats, assessments_href, access_controller, export_href, assessment_tracker_href, round_application_fields_download_available, sorting_date) %}
 <div class="govuk-!-padding-0 govuk-!-padding-right-2 govuk-!-padding-bottom-3 govuk-!-margin-bottom-6 govuk-grid-column-one-third content-container">
 
@@ -57,6 +74,8 @@
                     View all submitted applications
                 </a>
             {% endif %}
+            {{ round_links(access_controller, export_href, assessment_tracker_href) }}
+
         {% endif %}
         {% if assessment_stats %}
             {{ govukTable({
@@ -82,20 +101,8 @@
                 View all {% if is_assessment_active_status %}active{% else %}
                 closed{% endif %} assessments
             </a>
-            {% if round_application_fields_download_available and access_controller.is_lead_assessor %}
-            </br>
-            </br>
-            <a class="govuk-link" href="{{ export_href }}">
-                Export applicant information
-            </a>
-            {% endif %}
-            {% if access_controller.is_lead_assessor %}
-            </br>
-            </br>
-            <a class="govuk-link" href="{{ assessment_tracker_href }}">
-                Assessment Tracker Export
-            </a>
-            {% endif %}
+            {{ round_links(access_controller, export_href, assessment_tracker_href) }}
+
         {% endif %}
     </div>
 </div>

--- a/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
+++ b/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
@@ -17,17 +17,17 @@
     {% endif %}
 {% endmacro %}
 
-{% macro fund_summary(name, is_assessment_active_status, is_round_open_status, is_not_yet_open_status, fund_id, round_id, fund_name, round_name, assessment_stats, live_round_stats, assessments_href, access_controller, export_href, assessment_tracker_href, round_application_fields_download_available, sorting_date) %}
+{% macro fund_summary(summary, show_assessments_live_rounds) %}
 <div class="govuk-!-padding-0 govuk-!-padding-right-2 govuk-!-padding-bottom-3 govuk-!-margin-bottom-6 govuk-grid-column-one-third content-container">
 
     <div class="govuk-summary-card__title-wrapper">
-        <h3 class="govuk-body govuk_summary-card__title govuk-!-font-size-24">{{round_name}}</h3>
-        {% if access_controller.has_any_assessor_role %}
+        <h3 class="govuk-body govuk_summary-card__title govuk-!-font-size-24">{{summary.round_name}}</h3>
+        {% if summary.access_controller.has_any_assessor_role %}
         <ul class="govuk-summary-card__actions">
             <li class="govuk-summary-card__action">
                 <a class="govuk-link govuk-link__white_font govuk-!-margin-right-4"
                    data-qa="manage-tags"
-                   href="{{ url_for('tagging_bp.load_fund_round_tags', fund_id=fund_id, round_id=round_id) }}">
+                   href="{{ url_for('tagging_bp.load_fund_round_tags', fund_id=summary.fund_id, round_id=summary.round_id) }}">
                     Manage tags
                 </a>
             </li>
@@ -39,69 +39,71 @@
 
         <div>
             <strong
-                class="govuk-tag {% if not is_assessment_active_status and not is_round_open_status %}govuk-tag--grey{% endif %} govuk-!-margin-bottom-2 govuk-summary-card__title ">
-                {% if is_assessment_active_status %}
+                class="govuk-tag {% if not summary.is_assessment_active_status and not summary.is_round_open_status %}govuk-tag--grey{% endif %} govuk-!-margin-bottom-2 govuk-summary-card__title ">
+                {% if summary.is_assessment_active_status %}
                     ASSESSMENT ACTIVE
-                {% elif is_round_open_status %}
+                {% elif summary.is_round_open_status %}
                     APPLICATION LIVE
-                {% elif is_not_yet_open_status %}
+                {% elif summary.is_not_yet_open_status %}
                     APPLICATION NOT YET OPEN
                 {% else %}
                     ASSESSMENT CLOSED
                 {% endif %}
             </strong>
         </div>
-        {% if live_round_stats %}
+        {% if summary.live_round_stats %}
             {{ govukTable({
                 "caption": "",
                 "firstCellIsHeader": false,
                 "rows": [
                     [{'html': '<strong>Application closing date</strong>', 'classes': 'govuk-!-width-one-third'},
-                    {'text': live_round_stats.closing_date | datetime_format("%d %B %Y at %H:%M") }],
+                    {'text': summary.live_round_stats.closing_date | datetime_format("%d %B %Y at %H:%M") }],
                     [{'html': '<strong>Applications submitted</strong>'},
-                    {'text': live_round_stats.submitted if live_round_stats.submitted is not none else 'Unavailable'}],
+                    {'text': summary.live_round_stats.submitted if summary.live_round_stats.submitted is not none else 'Unavailable'}],
                     [{'html': '<strong>Applications in progress</strong>'},
-                    {'text': live_round_stats.in_progress if live_round_stats.in_progress is not none else 'Unavailable'}],
+                    {'text': summary.live_round_stats.in_progress if summary.live_round_stats.in_progress is not none else 'Unavailable'}],
                     [{'html': '<strong>Applications not started</strong>'},
-                    {'text': live_round_stats.not_started if live_round_stats.not_started is not none else 'Unavailable'}],
+                    {'text': summary.live_round_stats.not_started if summary.live_round_stats.not_started is not none else 'Unavailable'}],
                     [{'html': '<strong>Applications completed but not submitted</strong>'},
-                    {'text': live_round_stats.completed if live_round_stats.completed is not none else 'Unavailable'}],
+                    {'text': summary.live_round_stats.completed if summary.live_round_stats.completed is not none else 'Unavailable'}],
                     ],
                 })
             }}
-            {% if assessments_href %}
-                <a class="govuk-link" data-qa="dashboard_summary" href="{{ assessments_href }}">
+            {% if summary.assessments_href %}
+                <a class="govuk-link" data-qa="dashboard_summary" href="{{ summary.assessments_href }}">
                     View all submitted applications
                 </a>
             {% endif %}
-            {{ round_links(access_controller, export_href, assessment_tracker_href) }}
+            {% if show_assessments_live_rounds %}
+            {{ round_links(summary.access_controller, summary.export_href, summary.assessment_tracker_href) }}
+            {% endif %}
 
         {% endif %}
-        {% if assessment_stats %}
+        {% if summary.assessment_stats %}
             {{ govukTable({
             "caption": "",
             "firstCellIsHeader": false,
             "rows": [
             [{'html': '<strong>Assessment closing date</strong>', 'classes': 'govuk-!-width-one-third'},
-            {'text': assessment_stats.date | datetime_format("%d %B %Y at %H:%M") }],
+            {'text': summary.assessment_stats.date | datetime_format("%d %B %Y at %H:%M") }],
             [{'html': '<strong>Applications received</strong>'},
-            {'text': assessment_stats.total_received}],
+            {'text': summary.assessment_stats.total_received}],
             [{'html': '<strong>Assessments completed</strong>'},
-            {'text': assessment_stats.completed}],
+            {'text': summary.assessment_stats.completed}],
             [{'html': '<strong>Assessments started</strong>'},
-            {'text': assessment_stats.started}],
+            {'text': summary.assessment_stats.started}],
             [{'html': '<strong>QA Complete</strong>'},
-            {'text': assessment_stats.qa_complete}],
+            {'text': summary.assessment_stats.qa_complete}],
             [{'html': '<strong>Stopped assessments</strong>'},
-            {'text': assessment_stats.stopped}],
+            {'text': summary.assessment_stats.stopped}],
             ],
             }) }}
 
-            <a class="govuk-link" data-qa="dashboard_summary" href="{{ assessments_href }}">
+            <a class="govuk-link" data-qa="dashboard_summary" href="{{ summary.assessments_href }}">
                 View all {% if is_assessment_active_status %}active{% else %}
                 closed{% endif %} assessments
             </a>
-            {{ round_links(access_controller, export_href, assessment_tracker_href) }}
+            {{ round_links(summary.access_controller, summary.export_href, summary.assessment_tracker_href) }}
 
         {% endif %}
     </div>


### PR DESCRIPTION
- Adds "Export applicant information" & "Assessment Tracker Export" below rounds (even when live)
- Extracted macro & re-used in the two different places