### PR TITLE
FS-3450-update-scoring-page-navbar-sub-criteria-title-with-prefix-score

### DIFF
--- a/app/blueprints/scoring/templates/macros/scores_justification.html
+++ b/app/blueprints/scoring/templates/macros/scores_justification.html
@@ -62,8 +62,6 @@
         <div class="govuk-form-group">
             {% if latest_score %}
             <h2 class="govuk-heading-m">Rescore</h2>
-            {% else %}
-            <h2 class="govuk-heading-m">Score</h2>
             {% endif %}
             <p class="govuk-body">Score this sub criteria against the&nbsp;
                 <a class="govuk-link govuk-link--no-visited-state" href={{ state.fund_guidance_url }}>assessment

--- a/app/blueprints/scoring/templates/macros/sub_criteria_heading.html
+++ b/app/blueprints/scoring/templates/macros/sub_criteria_heading.html
@@ -1,0 +1,11 @@
+{% macro sub_criteria_heading(sub_criteria, score_form, rescore_form) %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+        {% set sub_criteria_heading = 'Score ' + sub_criteria.name|lower if score_form or rescore_form else sub_criteria.name %}
+        <h2 class="govuk-heading-l scoring-heading">{{ sub_criteria_heading }}</h2>
+
+    </div>
+</div>
+
+{% endmacro %}

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -5,6 +5,7 @@
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/flag_application_button.html" import flag_application_button %}
 {% from "macros/comments_summary.html" import comment_summary %}
+{% from "macros/sub_criteria_heading.html" import sub_criteria_heading %}
 {% set pageHeading -%}
 {% if score_form.errors.get('score') or score_form.errors.get('justification') %}
 Error:
@@ -43,16 +44,9 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
 {{ flag_application_button(application_id) }}
 {% endif %}
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-        {% set navbar_heading = 'Score ' + sub_criteria.name|lower if score_form or rescore_form else sub_criteria.name %}
-        <h2 class="govuk-heading-l scoring-heading">{{ navbar_heading }}</h2>
-
-    </div>
-</div>
+{{ sub_criteria_heading(sub_criteria, score_form, rescore_form)}}
 
 <div class="govuk-grid-row">
-
         <div class="govuk-grid-column-one-third">
             {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page=True) }}
         </div>
@@ -61,6 +55,5 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
             sub_criteria.id, scoring_list, state.fund_guidance_url) }}
             {{ comment_summary(comments,sub_criteria.themes) }}
         </div>
-
 </div>
 {% endblock content %}

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -45,7 +45,9 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-l scoring-heading">{{ sub_criteria.name }}</h2>
+        {% set navbar_heading = 'Score ' + sub_criteria.name|lower if score_form or rescore_form else sub_criteria.name %}
+        <h2 class="govuk-heading-l scoring-heading">{{ navbar_heading }}</h2>
+
     </div>
 </div>
 

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -33,6 +33,7 @@ from app.blueprints.assessments.models.applicants_response import (
     QuestionHeading,
 )
 from app.blueprints.authentication.validation import AssessmentAccessController
+from app.blueprints.scoring.forms.rescore_form import RescoreForm
 from app.blueprints.scoring.forms.scores_and_justifications import ScoreForm
 from app.blueprints.services.models.assessor_task_list import _Criteria
 from app.blueprints.services.models.assessor_task_list import (
@@ -910,4 +911,32 @@ class TestJinjaMacros(object):
         assert (
             soup.find("h2", class_="assessment-alert__heading").string
             == "All sections assessed"
+        )
+
+    @pytest.mark.parametrize(
+        "sub_criteria, expected_heading, has_forms",
+        [
+            ({"name": "Engagement"}, "Score engagement", True),
+            ({"name": "Engagement"}, "Engagement", False),
+            # Add more test cases as needed
+        ],
+    )
+    def test_sub_criteria_heading(
+        self, request_ctx, sub_criteria, expected_heading, has_forms
+    ):
+        rendered_html = render_template_string(
+            "{{sub_criteria_heading(sub_criteria, score_form, rescore_form)}}",
+            sub_criteria_heading=get_template_attribute(
+                "macros/sub_criteria_heading.html", "sub_criteria_heading"
+            ),
+            score_form=ScoreForm() if has_forms else None,
+            rescore_form=RescoreForm() if has_forms else None,
+            sub_criteria=sub_criteria,
+        )
+
+        soup = BeautifulSoup(rendered_html, "html.parser")
+
+        assert (
+            soup.find("h2", class_="govuk-heading-l scoring-heading").string
+            == expected_heading
         )


### PR DESCRIPTION
### Ticket 
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?quickFilter=343&selectedIssue=FS-3450

### Description
When a user clicks on the "score the subcriteria" link, the sub-criteria title will be prefixed with the word "Score," such as "Score Engagement." This is in accordance with the new prototype.

### Screenshots
![Screenshot 2023-09-14 at 17 02 18](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/74f95003-38c1-42db-bb0a-2dcda25a43b8)

![Screenshot 2023-09-14 at 17 06 03](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/8741b45b-406c-4cca-870c-1571017fa04d)


