### PR TITLE
FS-3441 added pre-commit hook yelp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
       - id: reorder-python-imports
         name: Reorder Python imports (src, tests)
         args: ["--application-directories", "src"]
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--disable-plugin', 'Base64HighEntropyString']
+        exclude: tests/keys/rsa256

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
     rev: v1.4.0
     hooks:
     -   id: detect-secrets
-        args: ['--disable-plugin', 'Base64HighEntropyString']
+        args: ['--disable-plugin', 'HexHighEntropyString']
         exclude: tests/keys/rsa256

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -248,7 +248,9 @@ class DefaultConfig:
             environ.get("VCAP_SERVICES")
         )
 
-        if VCAP_SERVICES.does_service_exist(service_key="aws-s3-bucket"):
+        if VCAP_SERVICES.does_service_exist(
+            service_key="aws-s3-bucket"  # pragma: allowlist secret
+        ):
             s3_credentials = VCAP_SERVICES.services.get("aws-s3-bucket")[
                 0
             ].get("credentials")

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -88,6 +88,6 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -115,3 +115,7 @@ the following while in your virtual enviroment:
 
 Once the above is done you will have autoformatting and pep8 compliance built
 into your workflow. You will be notified of any pep8 errors during commits.
+
+### `detect-secrets` hook
+We use this pre-commit hook to prevent new secrets from entering the code base.(For more info: https://github.com/Yelp/detect-secrets)
+- If the hook detects false positives, mark with an inline `pragma: allowlist secret` comment to ignore it.

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,7 +13,7 @@ applications:
     FUND_STORE_API_HOST: https://funding-service-design-fund-store-dev.london.cloudapps.digital
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-dev.london.cloudapps.digital
     ASSESSMENT_STORE_API_HOST: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
-    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.dev.gids.dev
+    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://cae245fff7d8483e9d73c73b30137ffc@o1432034.ingest.sentry.io/4504418515550208
@@ -38,7 +38,7 @@ applications:
     ASSESSMENT_STORE_API_HOST: https://funding-service-design-assessment-store-test.london.cloudapps.digital
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-test.london.cloudapps.digital
     FUND_STORE_API_HOST: https://funding-service-design-fund-store-test.london.cloudapps.digital
-    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.test.gids.dev
+    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.test.gids.dev  # pragma: allowlist secret
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://cae245fff7d8483e9d73c73b30137ffc@o1432034.ingest.sentry.io/4504418515550208


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Change description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugin `HexHighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 

