### PR TITLE
FS-3340-fix-dashboard-metrics-changes-based-on-filters

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -227,7 +227,8 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
 
     # note, we are not sending search parameters here as we don't want to filter
     # the stats at all.  see https://dluhcdigital.atlassian.net/browse/FS-3249
-    stats = process_assessments_stats(application_overviews)
+    stats = process_assessments_stats(applications_metadata)
+
     teams_flag_stats = get_team_flag_stats(application_overviews)
 
     # this is only used for querying applications, so remove it from the search params,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ from app.blueprints.services.models.flag import Flag
 from app.blueprints.services.models.fund import Fund
 from app.blueprints.shared.helpers import determine_display_status
 from app.blueprints.shared.helpers import is_flaggable
+from app.blueprints.shared.helpers import process_assessments_stats
 
 RAISED_FLAG = [
     Flag.from_dict(
@@ -231,3 +232,30 @@ def test_generate_maps_from_form_names_nested_case():
     )
     assert title_map == expected_title
     assert path_map == expected_path
+
+
+@pytest.mark.parametrize(
+    "input_data, expected_response",
+    [
+        (
+            [
+                {
+                    "workflow_status": "NOT_STARTED",
+                    "flags": [],
+                    "is_qa_complete": False,
+                },
+                {
+                    "workflow_status": "NOT_STARTED",
+                    "flags": [],
+                    "is_qa_complete": True,
+                },
+            ],
+            {"total": 2, "qa_completed": 1},
+        )
+    ],
+)
+def test_process_assessment_stats(input_data, expected_response):
+    stats = process_assessments_stats(input_data)
+
+    assert stats["total"] == expected_response["total"]
+    assert stats["qa_completed"] == expected_response["qa_completed"]


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?quickFilter=343&selectedIssue=FS-3340

### Description
This PR fixes the dashboard metrics issue that shouldn't change when search filters are applied.

### How to test
Unit test has been added 

### Screenshots
![Screenshot 2023-09-19 at 14 35 23](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/c902790d-ebbb-40af-a1b1-4b3fe038f213)

