### PR TITLE
FS-3467: Refactor guidance_url to be part of round

### DIFF
--- a/app/blueprints/scoring/templates/macros/scores_justification.html
+++ b/app/blueprints/scoring/templates/macros/scores_justification.html
@@ -2,7 +2,7 @@
 {% from "macros/justification.html" import justification %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, scoring_list, state) %}
+{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, scoring_list, fund_guidance_url) %}
 
 <div class="govuk-grid-column-full s26-scoring">
     {% if latest_score %}
@@ -64,11 +64,11 @@
             <h2 class="govuk-heading-m govuk-!-margin-top-4">Rescore</h2>
             {% endif %}
             <p class="govuk-body">Score this sub criteria against the
-                <a class="govuk-link govuk-link--no-visited-state" href={{ state.fund_guidance_url }}>assessment
+                <a class="govuk-link govuk-link--no-visited-state" href={{ fund_guidance_url }}>assessment
                     criteria</a>.</p>
             <p class="govuk-body">You can use the comments about this subcriteria from other assessors to inform your score.</p>
             {{ scores(score_form, scoring_list) }}
-            {{ justification(score_form, state.fund_guidance_url) }}
+            {{ justification(score_form, fund_guidance_url) }}
         </div>
         {% if latest_score %}
             {{ govukButton({'text': 'Save a new score', 'type':'submit', 'classes': 'primary-button'}) }}

--- a/app/blueprints/scoring/templates/macros/scores_justification.html
+++ b/app/blueprints/scoring/templates/macros/scores_justification.html
@@ -2,7 +2,7 @@
 {% from "macros/justification.html" import justification %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, scoring_list, fund_guidance_url) %}
+{% macro scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id, sub_criteria_id, scoring_list, round_guidance_url) %}
 
 <div class="govuk-grid-column-full s26-scoring">
     {% if latest_score %}
@@ -64,11 +64,11 @@
             <h2 class="govuk-heading-m govuk-!-margin-top-4">Rescore</h2>
             {% endif %}
             <p class="govuk-body">Score this sub criteria against the
-                <a class="govuk-link govuk-link--no-visited-state" href={{ fund_guidance_url }}>assessment
+                <a class="govuk-link govuk-link--no-visited-state" href={{ round_guidance_url }}>assessment
                     criteria</a>.</p>
             <p class="govuk-body">You can use the comments about this subcriteria from other assessors to inform your score.</p>
             {{ scores(score_form, scoring_list) }}
-            {{ justification(score_form, fund_guidance_url) }}
+            {{ justification(score_form, round_guidance_url) }}
         </div>
         {% if latest_score %}
             {{ govukButton({'text': 'Save a new score', 'type':'submit', 'classes': 'primary-button'}) }}

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -53,7 +53,7 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
         <div class="theme govuk-grid-column-two-thirds">
             {{ scores_justification(score_form, rescore_form, is_rescore, score_list, latest_score, application_id,
             sub_criteria.id, scoring_list, state.fund_guidance_url) }}
-            {{ comment_summary(comments,sub_criteria.themes) }}
+            {{ comment_summary(comments, sub_criteria.themes) }}
         </div>
 </div>
 {% endblock content %}

--- a/app/blueprints/services/models/fund.py
+++ b/app/blueprints/services/models/fund.py
@@ -12,7 +12,6 @@ class Fund:
     id: str
     description: str
     short_name: str
-    guidance_url: str = ""
     owner_organisation_name: str = ""
     owner_organisation_shortname: str = ""
     owner_organisation_logo_uri: str = ""
@@ -25,7 +24,6 @@ class Fund:
             id=data.get("id"),
             description=data.get("description"),
             short_name=data.get("short_name"),
-            guidance_url=data.get("guidance_url"),
             owner_organisation_name=data.get("owner_organisation_name"),
             owner_organisation_shortname=data.get(
                 "owner_organisation_shortname"

--- a/app/blueprints/services/models/round.py
+++ b/app/blueprints/services/models/round.py
@@ -14,6 +14,7 @@ class Round:
     opens: str
     title: str
     short_name: str
+    guidance_url: str = ""
     all_uploaded_documents_section_available: bool = False
     application_fields_download_available: bool = False
     display_logo_on_pdf_exports: bool = False
@@ -38,6 +39,7 @@ class Round:
             fund_id=data.get("fund_id"),
             opens=data.get("opens"),
             deadline=data.get("deadline"),
+            guidance_url=data.get("guidance_url"),
             all_uploaded_documents_section_available=data.get(
                 "all_uploaded_documents_section_available"
             )

--- a/app/blueprints/services/shared_data_helpers.py
+++ b/app/blueprints/services/shared_data_helpers.py
@@ -14,6 +14,6 @@ def get_state_for_tasklist_banner(application_id) -> AssessorTaskList:
     assessor_task_list_metadata["fund_name"] = fund.name
     assessor_task_list_metadata["fund_short_name"] = fund.short_name
     assessor_task_list_metadata["round_short_name"] = round.short_name
-    assessor_task_list_metadata["fund_guidance_url"] = fund.guidance_url
+    assessor_task_list_metadata["fund_guidance_url"] = round.guidance_url
     state = AssessorTaskList.from_json(assessor_task_list_metadata)
     return state


### PR DESCRIPTION
### Change description

- Refactor code to take `guidance_url` as part of the round rather than fund, prime example is COF round 3 having a different url than round 2, therefore it makes sense to have it round specific instead of round specific.
- Fix bug with the guidance url not being referenced properly in the scope templates, we were passing in the fund url as a string but had it referred to as state, so was calling a string `.fund_guidance_url` and failing

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines 


### How to test

- Deploy this branch
- Open assessment and select an application
- Navigate to a scored section
- Go to make a score, and click on the `assessment criteria` hyperlink
- Observe the correct url corresponding to the round

### Relevant PRs:

- https://github.com/communitiesuk/funding-service-design-fund-store/pull/146
