### PR TITLE
FS-3339 added lru cache for fund store endpoints

### DIFF
--- a/app/blueprints/assessments/models/fund_summary.py
+++ b/app/blueprints/assessments/models/fund_summary.py
@@ -11,6 +11,8 @@ from app.blueprints.services.data_services import get_application_stats
 from app.blueprints.services.data_services import get_assessments_stats
 from app.blueprints.services.data_services import get_rounds
 from app.blueprints.services.models.fund import Fund
+from app.blueprints.shared.helpers import get_ttl_hash
+from config import Config
 from config.display_value_mappings import ALL_VALUE
 from config.display_value_mappings import LandingFilters
 from flask import current_app
@@ -71,7 +73,9 @@ def create_round_summaries(
     summaries = []
     live_rounds = []
     round_id_to_summary_map = {}
-    for round in get_rounds(fund.id):
+    for round in get_rounds(
+        fund.id, ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME)
+    ):
         search_params = {}
         assessments_href = url_for(
             "assessment_bp.fund_dashboard",

--- a/app/blueprints/authentication/auth.py
+++ b/app/blueprints/authentication/auth.py
@@ -33,7 +33,7 @@ def auth_protect(minimum_roles_required: list, unprotected_routes: list):
     minimum_roles_required = [
         f"{fund.short_name}_{role}".upper()
         for fund in get_funds(
-            get_ttl_hash(seconds=300)
+            get_ttl_hash(seconds=Config.LRU_CACHE_TIME)
         )  # expensive call, so cache it & refresh every 5 minutes
         for role in minimum_roles_required
     ]

--- a/app/blueprints/authentication/validation.py
+++ b/app/blueprints/authentication/validation.py
@@ -8,7 +8,9 @@ from typing import Sequence
 
 from app.blueprints.services.data_services import get_application_metadata
 from app.blueprints.services.data_services import get_fund
+from app.blueprints.shared.helpers import get_ttl_hash
 from app.blueprints.shared.helpers import get_value_from_request
+from config import Config
 from flask import abort
 from flask import g
 from fsd_utils.authentication.decorators import login_required
@@ -117,7 +119,10 @@ def check_access_application_id(
             abort(404)
 
         application_metadata = get_application_metadata(application_id)
-        short_name = get_fund(application_metadata["fund_id"]).short_name
+        short_name = get_fund(
+            application_metadata["fund_id"],
+            ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+        ).short_name
         if not has_access_to_fund(short_name):
             abort(403)
 
@@ -165,7 +170,9 @@ def _check_access_fund_common(
         short_name = (
             fund_value
             if fund_key == "fund_short_name"
-            else get_fund(fund_value).short_name
+            else get_fund(
+                fund_value, ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME)
+            ).short_name
         )
         fund_roles_required = _get_roles_by_fund_short_name(
             short_name, roles_required

--- a/app/blueprints/flagging/helpers.py
+++ b/app/blueprints/flagging/helpers.py
@@ -4,6 +4,8 @@ from app.blueprints.services.data_services import get_sub_criteria_banner_state
 from app.blueprints.services.data_services import submit_flag
 from app.blueprints.shared.helpers import determine_assessment_status
 from app.blueprints.shared.helpers import determine_flag_status
+from app.blueprints.shared.helpers import get_ttl_hash
+from config import Config
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -67,7 +69,10 @@ def resolve_application(
     )
     flag_status = determine_flag_status(flags_list)
 
-    fund = get_fund(sub_criteria_banner_state.fund_id)
+    fund = get_fund(
+        sub_criteria_banner_state.fund_id,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
     return render_template(
         page_to_render,
         application_id=application_id,

--- a/app/blueprints/flagging/routes.py
+++ b/app/blueprints/flagging/routes.py
@@ -18,6 +18,7 @@ from app.blueprints.services.shared_data_helpers import (
 )
 from app.blueprints.shared.helpers import determine_assessment_status
 from app.blueprints.shared.helpers import determine_flag_status
+from app.blueprints.shared.helpers import get_ttl_hash
 from config import Config
 from flask import abort
 from flask import Blueprint
@@ -52,6 +53,7 @@ def flag(application_id):
     teams_available = get_available_teams(
         state.fund_id,
         state.round_id,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
     )
 
     form = FlagApplicationForm(

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -256,7 +256,11 @@ def get_funds(ttl_hash=None) -> Union[List[Fund], None]:
     return []
 
 
-def get_fund(fid: str, use_short_name: bool = False) -> Union[Fund, None]:
+@lru_cache(maxsize=1)
+def get_fund(
+    fid: str, use_short_name: bool = False, ttl_hash=None
+) -> Union[Fund, None]:
+    del ttl_hash  # unused, but required for lru_cache
     endpoint = Config.FUND_STORE_API_HOST + Config.FUND_ENDPOINT.format(
         fund_id=fid, use_short_name=use_short_name
     )
@@ -271,7 +275,9 @@ def get_fund(fid: str, use_short_name: bool = False) -> Union[Fund, None]:
     return fund
 
 
-def get_rounds(fund_id: str) -> list[Round]:
+@lru_cache(maxsize=1)
+def get_rounds(fund_id: str, ttl_hash=None) -> list[Round]:
+    del ttl_hash  # unused, but required for lru_cache
     endpoint = Config.FUND_STORE_API_HOST + Config.ROUNDS_ENDPOINT.format(
         fund_id=fund_id
     )
@@ -284,9 +290,11 @@ def get_rounds(fund_id: str) -> list[Round]:
     return rounds
 
 
+@lru_cache(maxsize=1)
 def get_round(
-    fid: str, rid: str, use_short_name: bool = False
+    fid: str, rid: str, use_short_name: bool = False, ttl_hash=None
 ) -> Union[Round, None]:
+    del ttl_hash  # unused, but required for lru_cache
     round_endpoint = Config.FUND_STORE_API_HOST + Config.ROUND_ENDPOINT.format(
         fund_id=fid, round_id=rid, use_short_name=use_short_name
     )
@@ -298,7 +306,9 @@ def get_round(
     return None
 
 
-def get_available_teams(fund_id: str, round_id: str) -> list:
+@lru_cache(maxsize=1)
+def get_available_teams(fund_id: str, round_id: str, ttl_hash=None) -> list:
+    del ttl_hash  # unused, but required for lru_cache
     teams_available = get_data(
         Config.GET_AVIALABLE_TEAMS_FOR_FUND.format(
             fund_id=fund_id,
@@ -361,7 +371,10 @@ def get_score_and_justification(
 
 def match_score_to_user_account(scores, fund_short_name):
     account_ids = [score["user_id"] for score in scores]
-    bulk_accounts_dict = get_bulk_accounts_dict(account_ids, fund_short_name)
+    bulk_accounts_dict = get_bulk_accounts_dict(
+        account_ids,
+        fund_short_name,
+    )
     scores_with_account: list[Score] = [
         Score.from_dict(
             score
@@ -683,7 +696,10 @@ def match_comment_to_theme(comment_response, themes, fund_short_name):
         Returns a dictionary of comments.
     """
     account_ids = [comment["user_id"] for comment in comment_response]
-    bulk_accounts_dict = get_bulk_accounts_dict(account_ids, fund_short_name)
+    bulk_accounts_dict = get_bulk_accounts_dict(
+        account_ids,
+        fund_short_name,
+    )
 
     comments: list[Comment] = [
         Comment.from_dict(

--- a/app/blueprints/services/shared_data_helpers.py
+++ b/app/blueprints/services/shared_data_helpers.py
@@ -2,14 +2,20 @@ from app.blueprints.services.data_services import get_assessor_task_list_state
 from app.blueprints.services.data_services import get_fund
 from app.blueprints.services.data_services import get_round
 from app.blueprints.services.models.assessor_task_list import AssessorTaskList
+from app.blueprints.shared.helpers import get_ttl_hash
+from config import Config
 
 
 def get_state_for_tasklist_banner(application_id) -> AssessorTaskList:
     assessor_task_list_metadata = get_assessor_task_list_state(application_id)
-    fund = get_fund(assessor_task_list_metadata["fund_id"])
+    fund = get_fund(
+        assessor_task_list_metadata["fund_id"],
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
     round = get_round(
         assessor_task_list_metadata["fund_id"],
         assessor_task_list_metadata["round_id"],
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
     )
     assessor_task_list_metadata["fund_name"] = fund.name
     assessor_task_list_metadata["fund_short_name"] = fund.short_name

--- a/app/blueprints/shared/helpers.py
+++ b/app/blueprints/shared/helpers.py
@@ -127,6 +127,19 @@ def match_search_params(search_params, request_args):
 
 
 def get_ttl_hash(seconds=3600) -> int:
+    """
+    The @lru_cache decorator from the functools module in Python
+    requires that the decorated function takes arguments that are
+    hashable so that it can use those arguments as keys in its cache.
+
+    get_ttl_hash exploits the fact that lru_cache depends
+    on the 'ttl_hash' argument. The ttl_hash (result of this function)
+    will stay the same within a time period. If seconds is exceeded
+    within time.time(), we get a different hash value.
+    ttl_hash changes. lru_cache can't find a cache key for this new value and
+    calls the cacheable function.
+    (deleting the other if it exceeds the maxsize cache limit).
+    """
     return round(time.time() / seconds)
 
 

--- a/app/blueprints/tagging/routes.py
+++ b/app/blueprints/tagging/routes.py
@@ -22,6 +22,7 @@ from app.blueprints.services.shared_data_helpers import (
     get_state_for_tasklist_banner,
 )
 from app.blueprints.shared.helpers import determine_assessment_status
+from app.blueprints.shared.helpers import get_ttl_hash
 from app.blueprints.shared.helpers import match_search_params
 from app.blueprints.tagging.forms.tags import DeactivateTagForm
 from app.blueprints.tagging.forms.tags import EditTagForm
@@ -93,8 +94,17 @@ def load_change_tags(application_id):
 
 
 def get_fund_round(fund_id, round_id) -> Dict:
-    fund = get_fund(fund_id, use_short_name=False)
-    round = get_round(fund_id, round_id, use_short_name=False)
+    fund = get_fund(
+        fund_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+    round = get_round(
+        fund_id,
+        round_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
     fund_round = {
         "fund_name": fund.name,
         "round_name": round.title,
@@ -206,8 +216,17 @@ def create_tag(fund_id, round_id):
 def deactivate_tag(fund_id, round_id, tag_id):
     deactivate_tag_form = DeactivateTagForm()
     tag_to_deactivate = get_tag_for_fund_round(fund_id, round_id, tag_id)
-    fund = get_fund(fund_id, use_short_name=False)
-    round = get_round(fund_id, round_id, use_short_name=False)
+    fund = get_fund(
+        fund_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+    round = get_round(
+        fund_id,
+        round_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
     fund_round = {
         "fund_name": fund.name,
         "round_name": round.title,
@@ -254,8 +273,17 @@ def deactivate_tag(fund_id, round_id, tag_id):
 def reactivate_tag(fund_id, round_id, tag_id):
     reactivate_tag_form = ReactivateTagForm()
     tag_to_reactivate = get_tag_for_fund_round(fund_id, round_id, tag_id)
-    fund = get_fund(fund_id, use_short_name=False)
-    round = get_round(fund_id, round_id, use_short_name=False)
+    fund = get_fund(
+        fund_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+    round = get_round(
+        fund_id,
+        round_id,
+        use_short_name=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
     fund_round = {
         "fund_name": fund.name,
         "round_name": round.title,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -273,3 +273,6 @@ class DefaultConfig:
     TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
     FEATURE_CONFIG = {"TAGGING": True}
     ASSETS_AUTO_BUILD = False
+
+    # LRU cache settings
+    LRU_CACHE_TIME = int(environ.get("LRU_CACHE_TIME", 3600))  # in seconds

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -41,9 +41,12 @@ class DevelopmentConfig(DefaultConfig):
             "COF_SCOTLAND",
             "COF_WALES",
             "COF_NORTHERNIRELAND",
-            # "NSTF_LEAD_ASSESSOR",
+            "NSTF_LEAD_ASSESSOR",
             "NSTF_ASSESSOR",
             "NSTF_COMMENTER",
+            "CYP_LEAD_ASSESSOR",
+            "CYP_ASSESSOR",
+            "CYP_COMMENTER",
         ],
         "highest_role_map": {"COF": DEBUG_USER_ROLE, "NSTF": DEBUG_USER_ROLE},
     }
@@ -67,3 +70,6 @@ class DevelopmentConfig(DefaultConfig):
 
     FEATURE_CONFIG = {"TAGGING": True}
     ASSETS_AUTO_BUILD = True
+
+    # LRU cache settings
+    LRU_CACHE_TIME = 30  # in seconds

--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -17,3 +17,6 @@ class TestConfig(DefaultConfig):
         )
 
     TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
+
+    # LRU cache settings
+    LRU_CACHE_TIME = 300  # in seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,11 @@ from unittest import mock
 import jwt as jwt
 import pytest
 from app.blueprints.services.models.assessor_task_list import AssessorTaskList
+from app.blueprints.shared.helpers import get_ttl_hash
 from app.blueprints.tagging.models.tag import AssociatedTag
 from app.blueprints.tagging.models.tag import Tag
 from app.blueprints.tagging.models.tag import TagType
+from config import Config
 from create_app import create_app
 from flask import template_rendered
 from selenium import webdriver
@@ -370,7 +372,9 @@ def mock_get_rounds(request, mocker):
     yield mocked_get_rounds
 
     for mocked_round in mocked_get_rounds:
-        mocked_round.assert_called_with(fund_id)
+        mocked_round.assert_called_with(
+            fund_id, ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME)
+        )
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,0 +1,39 @@
+import time
+
+from app.blueprints.services.data_services import get_fund
+from app.blueprints.shared.helpers import get_ttl_hash
+
+
+def test_get_fund_lru_cache(mocker):
+    fund_args = {
+        "name": "Testing Fund",
+        "short_name": "",
+        "description": "",
+        "welsh_available": True,
+        "title": "Test Fund by ID",
+        "id": "222",
+    }
+    mocker.patch(
+        "app.blueprints.services.data_services.get_data",
+        return_value=fund_args,
+    )
+    # `get_fund`'s output is cached for 2 sec's
+    fund = get_fund(fid="222", ttl_hash=get_ttl_hash(seconds=2))
+    assert fund.id == fund_args["id"]
+    assert fund.name == "Testing Fund"
+
+    # Now let's make another call to `get_fund` with modified fund data(in db) in less than 2 sec
+    fund_args["name"] = "Testing Fund 2"
+    mocker.patch(
+        "app.blueprints.services.data_services.get_data",
+        return_value=fund_args,
+    )
+    fund = get_fund(fid="222", ttl_hash=get_ttl_hash(seconds=2))
+    assert (
+        fund.name == "Testing Fund"
+    )  # observe that fund name is still equal to cached title
+
+    # Sleep for 2 seconds to reset the cache & make a fresh call to `get_fund`
+    time.sleep(2)
+    fund = get_fund(fid="222", ttl_hash=get_ttl_hash(seconds=2))
+    assert fund.name == "Testing Fund 2"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -198,7 +198,7 @@ def test_check_access_application_id_cant_access_application_when_no_country_rol
     )
     monkeypatch.setattr(
         "app.blueprints.authentication.validation.get_fund",
-        lambda _: Fund.from_json(
+        lambda *_, **__: Fund.from_json(
             {
                 "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
                 "short_name": "cof",
@@ -244,7 +244,7 @@ def test_check_access_application_id_can_access_application_when_has_country_rol
     )
     monkeypatch.setattr(
         "app.blueprints.authentication.validation.get_fund",
-        lambda _: Fund.from_json(
+        lambda *_, **__: Fund.from_json(
             {
                 "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
                 "short_name": "cof",
@@ -288,7 +288,7 @@ def test_check_access_application_id_can_access_application_when_fund_has_no_dev
     )
     monkeypatch.setattr(
         "app.blueprints.authentication.validation.get_fund",
-        lambda _: Fund.from_json(
+        lambda *_, **__: Fund.from_json(
             {
                 "id": "mock-nstf-fund-id",
                 "short_name": "nstf",
@@ -324,7 +324,7 @@ def test_check_access_application_id_cant_access_application_when_no_relevant_fu
     )
     monkeypatch.setattr(
         "app.blueprints.authentication.validation.get_fund",
-        lambda _: Fund.from_json(
+        lambda *_, **__: Fund.from_json(
             {
                 "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
                 "short_name": "cof",


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3339

### Description
- Implemented lru caching for fund store endpoints
- Updated & added unittests
- Cache time is set as 3600s on prod, 300s on test & 30s on dev

As initially thought, implementing LRU cache on assessment store endpoints is not the solution for performance improvement. As any caching on the assessment store endpoint will not reflect changes made by assessors on flagging or tagging immediately. So caching is added only for fund-store endpoints in this PR. Please look at the ticket comment in Jira for more information.

### How to test
- Put breakpoints in the get_fund and get_round methods of fund_store
- Load the assessment frontend in a browser and check that the above breakpoints don't get hit except on the first retrieval of a session (ie the frontend has cached the data)

### Screenshots of UI changes (if applicable)
