### PR TITLE
FS-3699 Fix for not supplied if address is None

### DIFF
--- a/app/blueprints/assessments/models/applicants_response.py
+++ b/app/blueprints/assessments/models/applicants_response.py
@@ -107,7 +107,9 @@ class FormattedBesideQuestionAnswerPair(QuestionAnswerPair):
     def from_dict(cls, data: dict, formatter: callable):  # noqa
         return cls(
             question=data["question"],
-            answer=data.get("answer", ANSWER_NOT_PROVIDED_DEFAULT),
+            answer=data["answer"]
+            if data["answer"]
+            else ANSWER_NOT_PROVIDED_DEFAULT,
             formatter=formatter if data.get("answer") else lambda x: x,
         )
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3699

### Change description
Optional UkAddressFields will now say not supplied when no answer is given

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Find an application with an optional address filed and leave it blank. Should now show not supplied on frontend


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/bc29bb01-9648-4eb2-a182-e63533cde76d)
