### PR TITLE
Fs 3705 assessor comment editing

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -397,6 +397,22 @@ def display_sub_criteria(
             )
         )
 
+    edit_comment_argument = request.args.get("edit_comment")
+    comment_id = request.args.get("comment_id")
+    if edit_comment_argument and comment_form.validate_on_submit():
+        comment = comment_form.comment.data
+        submit_comment(comment=comment, comment_id=comment_id)
+
+        return redirect(
+            url_for(
+                "assessment_bp.display_sub_criteria",
+                application_id=application_id,
+                sub_criteria_id=sub_criteria_id,
+                theme_id=theme_id,
+                _anchor="comments",
+            )
+        )
+
     state = get_state_for_tasklist_banner(application_id)
     flags_list = get_flags(application_id)
 
@@ -426,6 +442,8 @@ def display_sub_criteria(
         "comments": theme_matched_comments,
         "is_flaggable": False,  # Flag button is disabled in sub-criteria page,
         "display_comment_box": add_comment_argument,
+        "display_comment_edit_box": edit_comment_argument,
+        "comment_id": comment_id,
         "comment_form": comment_form,
         "current_theme": current_theme,
         "flag_status": flag_status,

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -40,23 +40,4 @@
     {% endfor %}
     {% endif %}
 </div>
-{# <form class="govuk-!-margin-top-2" action="./community-engagement#anchor" method="POST">
-    <div class="govuk-form-group govuk-!-margin-top-7">
-        <div class="govuk-form-group govuk-!-margin-top-2">
-          <label class="govuk-label govuk-label--m">
-            Edit comment
-          </label>
-          <div class="s26-comment-group">
-            <p class="govuk-body">This is a comment that has been left by you and has the ability to be edited as well as see previous edits for this comment.</p>
-            <p class="govuk-body-s">Your name (Assessor) yourname@assessment.org.uk</p>
-            <p class="govuk-body-s">19/05/2022 at 14:58</p>
-          </div>
-          <textarea class="govuk-textarea" id="s26-community-engagement-comment-2" name="s26-community-engagement-comment-2" value="" rows="8" autofocus="" spellcheck="false">This is a comment that has been left by you and has the ability to be edited as well as see previous edits for this comment.
-          </textarea>
-          <button id="comment-button-community" class="govuk-button primary-button" data-module="govuk-button" type="submit" value="save-comment">
-            Save comment
-          </button>
-        </div>
-    </div>
-</form> #}
 {% endmacro %}

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -29,9 +29,9 @@
                             edit_comment="1",
                             comment_id=comment.id
                         ) }}" >Edit comment</a>
-                        {% if comment.updates|length > 1 %}
+                        {# {% if comment.updates|length > 1 %}
                             <a class="govuk-link" href="./comment-history.html">See history</a>
-                        {% endif %}
+                        {% endif %} #}
                     </div>
                 {% endif %}
             </div>

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -3,7 +3,6 @@
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Comments</h2>
     <div id="more-detail-hint" class="govuk-hint">
       <p class="govuk-hint govuk-!-margin-top-0">Summarise any thoughts you have on the information provided.</p>
-      <p class="govuk-hint govuk-!-margin-top-0">You cannot edit or delete your comment once you have saved it.</p>
     </div>
     {% if comments == None %}
     <div class="govuk-body govuk-!-margin-top-6">
@@ -18,13 +17,46 @@
             </div>
         {% else %}
             <div class="comment-group">
-                <p class="govuk-body">{{ comment.comment }}</p>
+                <p class="govuk-body">{{ comment.updates[-1]['comment'] }}</p>
                 <p class="govuk-body-s">{{ comment.full_name }} ({{ comment.highest_role|all_caps_to_human }}) {{ comment.email_address }}</p>
                 <p class="govuk-body-s">{{ comment.date_created|utc_to_bst }}</p>
+                {% if g.account_id == comment.user_id %}
+                    <div class="govuk-button-group">
+                        <a class="govuk-link" href="{{ url_for(
+                            "assessment_bp.display_sub_criteria",
+                            application_id=comment.application_id,
+                            sub_criteria_id=comment.sub_criteria_id,
+                            edit_comment="1",
+                            comment_id=comment.id
+                        ) }}" >Edit comment</a>
+                        {% if comment.updates|length > 1 %}
+                            <a class="govuk-link" href="./comment-history.html">See history</a>
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
         {% endfor %}
     {% endfor %}
     {% endif %}
 </div>
+{# <form class="govuk-!-margin-top-2" action="./community-engagement#anchor" method="POST">
+    <div class="govuk-form-group govuk-!-margin-top-7">
+        <div class="govuk-form-group govuk-!-margin-top-2">
+          <label class="govuk-label govuk-label--m">
+            Edit comment
+          </label>
+          <div class="s26-comment-group">
+            <p class="govuk-body">This is a comment that has been left by you and has the ability to be edited as well as see previous edits for this comment.</p>
+            <p class="govuk-body-s">Your name (Assessor) yourname@assessment.org.uk</p>
+            <p class="govuk-body-s">19/05/2022 at 14:58</p>
+          </div>
+          <textarea class="govuk-textarea" id="s26-community-engagement-comment-2" name="s26-community-engagement-comment-2" value="" rows="8" autofocus="" spellcheck="false">This is a comment that has been left by you and has the ability to be edited as well as see previous edits for this comment.
+          </textarea>
+          <button id="comment-button-community" class="govuk-button primary-button" data-module="govuk-button" type="submit" value="save-comment">
+            Save comment
+          </button>
+        </div>
+    </div>
+</form> #}
 {% endmacro %}

--- a/app/blueprints/assessments/templates/macros/comments_box.html
+++ b/app/blueprints/assessments/templates/macros/comments_box.html
@@ -1,7 +1,7 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro comment_box(comment_form) %}
+{% macro comment_box(comment_form, html_text, placeholder) %}
 
 <form method="post">
 <div class="govuk-grid-row">
@@ -12,10 +12,12 @@
     "id": comment_form.comment.id,
     "rows": 8,
     "label": {
-      "text": "Add a comment",
+      "text": "" if html_text else "Add a comment",
+      "html": html_text if html_text else "",
       "classes": "govuk-label--m",
       isPageHeading: true
     },
+    "value": placeholder if placeholder else "",
     "errorMessage": {
       "text": comment_form.comment.errors.0
   } if comment_form.comment.errors

--- a/app/blueprints/assessments/templates/macros/comments_edit_box.html
+++ b/app/blueprints/assessments/templates/macros/comments_edit_box.html
@@ -1,0 +1,30 @@
+{% from "macros/comments_box.html" import comment_box %}
+
+{% macro edit_comment_box(comments, comment_id, comment_form) %}
+
+  {# Using namespace objects to access variables set outside of for loop #}
+  {% set comment_text = namespace(str = "") %}
+  {% set comment_author = namespace(str = "") %}
+  {% set comment_date = namespace(str = "") %}
+
+  {% for comment_list in comments.values() %}
+    {% for comment in comment_list %}
+        {% if comment.id == comment_id %}
+          {% set comment_text.str = comment.updates[-1]['comment'] %}
+          {% set comment_author.str =  comment.full_name + " (" + comment.highest_role|all_caps_to_human + ") "+ comment.email_address %}
+          {% set comment_date.str = comment.date_created|utc_to_bst %}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+
+  {% set HtmlData %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Edit comment</h2>
+    <div class="comment-group">
+      <p class="govuk-body">{{ comment_text.str }}</p>
+      <p class="govuk-body-s">{{ comment_author.str }}</p>
+      <p class="govuk-body-s">{{ comment_date.str }}</p>
+    </div>
+  {% endset %}
+
+  {{ comment_box(comment_form, HtmlData, comment_text.str) }}
+{% endmacro %}

--- a/app/blueprints/assessments/templates/sub_criteria.html
+++ b/app/blueprints/assessments/templates/sub_criteria.html
@@ -4,6 +4,7 @@
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/flag_application_button.html" import flag_application_button %}
 {% from "macros/comments.html" import comment %}
+{% from "macros/comments_edit_box.html" import edit_comment_box %}
 {% from "macros/comments_box.html" import comment_box %}
 
 {% set pageHeading -%}
@@ -55,7 +56,7 @@ Error:
         <div class="theme govuk-grid-column-two-thirds">
             {{ theme(answers_meta)}}
             {{ comment(comments)}}
-            {% if display_comment_box != True %}
+            {% if display_comment_box != True and not display_comment_edit_box %}
                 <a
                     id="comment"
                     class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"
@@ -78,6 +79,9 @@ Error:
 
                 {% if display_comment_box == True %}
                     {{ comment_box(comment_form) }}
+                {% endif %}
+                {% if display_comment_edit_box %}
+                    {{ edit_comment_box(comments, comment_id, comment_form)}}
                 {% endif %}
         </div>
 </div>

--- a/app/blueprints/scoring/templates/macros/comments_summary.html
+++ b/app/blueprints/scoring/templates/macros/comments_summary.html
@@ -16,7 +16,7 @@
         </div>
         {% else %}
         <div class="comment-group">
-            <p class="govuk-body">{{ comment.comment }}</p>
+            <p class="govuk-body">{{ comment.updates[-1].comment }}</p>
             <p class="govuk-body-s">{{ comment.full_name }} ({{ comment.highest_role|all_caps_to_human }})
                 {{ comment.email_address }}</p>
             <p class="govuk-body-s">{{ comment.date_created|utc_to_bst }}</p>

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -729,22 +729,35 @@ def match_comment_to_theme(comment_response, themes, fund_short_name):
 
 
 def submit_comment(
-    comment, application_id, sub_criteria_id, user_id, theme_id
+    comment,
+    application_id=None,
+    sub_criteria_id=None,
+    user_id=None,
+    theme_id=None,
+    comment_id=None,
 ):
-    data_dict = {
-        "comment": comment,
-        "user_id": user_id,
-        "application_id": application_id,
-        "sub_criteria_id": sub_criteria_id,
-        "comment_type": "COMMENT",
-        "theme_id": theme_id,
-    }
-    url = Config.ASSESSMENT_COMMENT_ENDPOINT
-    response = requests.post(url, json=data_dict)
+    if not comment_id:
+        data_dict = {
+            "comment": comment,
+            "user_id": user_id,
+            "application_id": application_id,
+            "sub_criteria_id": sub_criteria_id,
+            "comment_type": "COMMENT",
+            "theme_id": theme_id,
+        }
+        url = Config.ASSESSMENT_COMMENT_ENDPOINT
+        response = requests.post(url, json=data_dict)
+    else:
+        data_dict = {
+            "comment": comment,
+            "comment_id": comment_id,
+        }
+        url = Config.ASSESSMENT_COMMENT_ENDPOINT
+        response = requests.put(url, json=data_dict)
+
     current_app.logger.info(
         f"Response from Assessment Store: '{response.json()}'."
     )
-
     return response.ok
 
 

--- a/app/blueprints/services/models/comment.py
+++ b/app/blueprints/services/models/comment.py
@@ -1,10 +1,11 @@
 import inspect
 from dataclasses import dataclass
+from datetime import datetime
 
 
 @dataclass
 class Comment:
-    comment: str
+    id: str
     user_id: str
     date_created: str
     email_address: str
@@ -12,6 +13,21 @@ class Comment:
     highest_role: str
     theme_id: str
     fund_short_name: str
+    updates: list
+    application_id: str
+    sub_criteria_id: str
+
+    def __post_init__(self):
+        for item in self.updates:
+            item["date_created"] = datetime.fromisoformat(
+                item["date_created"]
+            ).strftime("%Y-%m-%d %X")
+
+        # sort the updates in the order they are created
+        if self.updates:
+            self.updates = sorted(
+                self.updates, key=lambda x: x["date_created"]
+            )
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 
 test_fund_id = "test-fund"
 test_round_id = "test-round"
-test_user_id_lead_assessor = "test_user_lead_assessor"
-test_user_id_assessor = "test_user_assessor"
-test_user_id_commenter = "test_user_commenter"
+test_user_id_lead_assessor = "lead"
+test_user_id_assessor = "assessor"
+test_user_id_commenter = "commenter"
 test_funding_requested = 5000.0
 
 # application specific config

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -583,34 +583,79 @@ mock_api_results = {
     ],
     "assessment_store/comment?": [
         {
-            "comment": "This is a comment",
+            "id": "test_id_1",
             "user_id": test_user_id_lead_assessor,
             "date_created": "2022-12-08T08:00:01.748170",
             "theme_id": resolved_app["theme_id"],
+            "sub_criteria_id": "test_sub_criteria_id",
+            "application_id": resolved_app["id"],
+            "updates": [
+                {
+                    "comment": "This is a comment",
+                    "comment_id": "test_id_1",
+                    "date_created": "2022-12-08T08:00:01.748170",
+                }
+            ],
         },
         {
-            "comment": "You're missing some details",
+            "id": "test_id_2",
             "user_id": test_user_id_lead_assessor,
             "date_created": "2022-10-27T08:00:02.748170",
             "theme_id": resolved_app["theme_id"],
+            "sub_criteria_id": "test_sub_criteria_id",
+            "application_id": resolved_app["id"],
+            "updates": [
+                {
+                    "comment": "You're missing some details",
+                    "comment_id": "test_id_2",
+                    "date_created": "2022-10-27T08:00:02.748170",
+                }
+            ],
         },
         {
-            "comment": "Im a lead assessor",
+            "id": "test_id_3",
             "user_id": test_user_id_lead_assessor,
             "date_created": "2022-10-27T08:00:03.748170",
             "theme_id": resolved_app["theme_id"],
+            "sub_criteria_id": "test_sub_criteria_id",
+            "application_id": resolved_app["id"],
+            "updates": [
+                {
+                    "comment": "You're missing some details",
+                    "comment_id": "test_id_3",
+                    "date_created": "2022-10-27T08:00:03.748170",
+                }
+            ],
         },
         {
-            "comment": "Im an assessor",
+            "id": "test_id_4",
             "user_id": test_user_id_assessor,
             "date_created": "2022-10-27T08:00:04.748170",
             "theme_id": resolved_app["theme_id"],
+            "sub_criteria_id": "test_sub_criteria_id",
+            "application_id": resolved_app["id"],
+            "updates": [
+                {
+                    "comment": "Im an assessor",
+                    "comment_id": "test_id_4",
+                    "date_created": "2022-10-27T08:00:04.748170",
+                }
+            ],
         },
         {
-            "comment": "Im a commenter",
+            "id": "test_id_5",
             "user_id": test_user_id_commenter,
             "date_created": "2022-10-27T08:00:05.748170",
             "theme_id": resolved_app["theme_id"],
+            "sub_criteria_id": "test_sub_criteria_id",
+            "application_id": resolved_app["id"],
+            "updates": [
+                {
+                    "comment": "Im a commenter",
+                    "comment_id": "test_id_5",
+                    "date_created": "2022-10-27T08:00:05.748170",
+                }
+            ],
         },
     ],
     "assessment_store/score?": [

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -306,7 +306,7 @@ class TestAuthorisation:
 
         for comment in all_comments:
             comment_str = str(comment)
-            # "Edit comment" is available only for comment owner
+            # "Edit comment" button is available only for the comment owner
             if claim["email"] in comment_str:
                 assert "Edit comment" in comment_str
             else:

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -298,6 +298,20 @@ class TestAuthorisation:
         )
         assert g.user.roles is not None
 
+        soup = BeautifulSoup(response.data, "html.parser")
+        all_comments = soup.find_all("div", class_="comment-group")
+
+        if claim["accountId"] == "commenter":
+            assert "Permission required to see comment." in str(all_comments)
+
+        for comment in all_comments:
+            comment_str = str(comment)
+            # "Edit comment" is available only for comment owner
+            if claim["email"] in comment_str:
+                assert "Edit comment" in comment_str
+            else:
+                assert "Edit comment" not in comment_str
+
         if expect_all_comments_available:
             assert is_lead_assessor_comment_visible
             assert is_assessor_comment_visible


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3705

### Description
Added "Edit comment" button for the comment owner
- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

Linked [PR](https://github.com/communitiesuk/funding-service-design-assessment-store/pull/342)

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/eaa99151-a901-48b2-88f3-18afdfca8db8)

