### PR TITLE
Fs 3731 add comment history

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -426,10 +426,14 @@ def display_sub_criteria(
 
     if comment_id and show_comment_history:
         comment_data = next(
-            cmnt if cmnt.id == comment_id else None
-            for cmnt in theme_matched_comments[theme_id]
+            (
+                cmnt
+                for cmnt in theme_matched_comments[theme_id]
+                if cmnt.id == comment_id
+            ),
+            None,
         )
-        if comment_data and g.account_id == comment_data.user_id:
+        if comment_data:
             return render_template(
                 "comments_history.html",
                 comment_data=comment_data,
@@ -443,8 +447,6 @@ def display_sub_criteria(
                 flag_status=flag_status,
                 assessment_status=assessment_status,
             )
-        else:
-            abort(403)
 
     if edit_comment_argument and comment_form.validate_on_submit():
         comment = comment_form.comment.data

--- a/app/blueprints/assessments/templates/assessor_tool_dashboard.html
+++ b/app/blueprints/assessments/templates/assessor_tool_dashboard.html
@@ -28,7 +28,7 @@
             <div class="govuk-accordion__controls">
                 <button type="button" class="govuk-accordion__show-all">
                     <span class="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span>
-                    <span class="govuk-accordion__show-all-text">Show all sections</span>
+                    <span class="govuk-accordion__show-all-text" data-qa="show_all_sections">Show all sections</span>
                 </button>
             </div>
             {% endif %}

--- a/app/blueprints/assessments/templates/comments_history.html
+++ b/app/blueprints/assessments/templates/comments_history.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
+{%- from "govuk_frontend_jinja/components/textarea/macro.html" import govukTextarea -%}
+
+{% block header %}
+{% include "./components/header.html" %}
+{% endblock header %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="content-container">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="">
+                <div class="govuk-button-group">
+                <a class="govuk-link" href="{{ back_href }}">Back to assessment</a>
+                </div>
+                <h1 class="govuk-heading-l">Comment edit history</h1>
+            </div>
+
+            {% set updates_length = comment_data.updates|length %}
+
+            {% for data in comment_data.updates|reverse %}
+                {% if loop.index0 < updates_length-1 %}
+                    <div class="comment-group">
+                        <p class="govuk-body">{{ data['comment'] }}.</p>
+                        <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
+                        <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
+                    </div>
+                {% else %}
+                    <div class="govuk-!-padding-top-7">
+                        <h2 class="govuk-heading-s govuk-!-padding-bottom-0">Original comment</h2>
+                        <div class="comment-group">
+                        <p class="govuk-body">{{ data['comment'] }}.</p>
+                        <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
+                        <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
+                        </div>
+                    </div>
+                {% endif %}
+            {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -20,16 +20,18 @@
                 <p class="govuk-body">{{ comment.updates[-1]['comment'] }}</p>
                 <p class="govuk-body-s">{{ comment.full_name }} ({{ comment.highest_role|all_caps_to_human }}) {{ comment.email_address }}</p>
                 <p class="govuk-body-s">{{ comment.updates[-1].date_created|utc_to_bst }}</p>
-                {% if g.account_id == comment.user_id %}
+                {% if g.account_id == comment.user_id or comment.updates|length > 1 %}
                     <div class="govuk-button-group">
-                        <a class="govuk-link" href="{{ url_for(
-                            "assessment_bp.display_sub_criteria",
-                            application_id=comment.application_id,
-                            sub_criteria_id=comment.sub_criteria_id,
-                            theme_id=comment.theme_id,
-                            edit_comment="1",
-                            comment_id=comment.id
-                        ) }}" >Edit comment</a>
+                        {% if g.account_id == comment.user_id %}
+                            <a class="govuk-link" href="{{ url_for(
+                                "assessment_bp.display_sub_criteria",
+                                application_id=comment.application_id,
+                                sub_criteria_id=comment.sub_criteria_id,
+                                theme_id=comment.theme_id,
+                                edit_comment="1",
+                                comment_id=comment.id
+                            ) }}" >Edit comment</a>
+                        {% endif %}
                         {% if comment.updates|length > 1 %}
                             <a class="govuk-link" href="{{  url_for(
                             "assessment_bp.display_sub_criteria",

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -26,6 +26,7 @@
                             "assessment_bp.display_sub_criteria",
                             application_id=comment.application_id,
                             sub_criteria_id=comment.sub_criteria_id,
+                            theme_id=comment.theme_id,
                             edit_comment="1",
                             comment_id=comment.id
                         ) }}" >Edit comment</a>

--- a/app/blueprints/assessments/templates/macros/comments.html
+++ b/app/blueprints/assessments/templates/macros/comments.html
@@ -19,7 +19,7 @@
             <div class="comment-group">
                 <p class="govuk-body">{{ comment.updates[-1]['comment'] }}</p>
                 <p class="govuk-body-s">{{ comment.full_name }} ({{ comment.highest_role|all_caps_to_human }}) {{ comment.email_address }}</p>
-                <p class="govuk-body-s">{{ comment.date_created|utc_to_bst }}</p>
+                <p class="govuk-body-s">{{ comment.updates[-1].date_created|utc_to_bst }}</p>
                 {% if g.account_id == comment.user_id %}
                     <div class="govuk-button-group">
                         <a class="govuk-link" href="{{ url_for(
@@ -29,9 +29,15 @@
                             edit_comment="1",
                             comment_id=comment.id
                         ) }}" >Edit comment</a>
-                        {# {% if comment.updates|length > 1 %}
-                            <a class="govuk-link" href="./comment-history.html">See history</a>
-                        {% endif %} #}
+                        {% if comment.updates|length > 1 %}
+                            <a class="govuk-link" href="{{  url_for(
+                            "assessment_bp.display_sub_criteria",
+                            application_id=comment.application_id,
+                            sub_criteria_id=comment.sub_criteria_id,
+                            theme_id=comment.theme_id,
+                            show_comment_history="1",
+                            comment_id=comment.id) }}">See history</a>
+                        {% endif %}
                     </div>
                 {% endif %}
             </div>

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -651,7 +651,10 @@ def get_sub_criteria_theme_answers(
 
 
 def get_comments(
-    application_id: str, sub_criteria_id: str, theme_id: str | None
+    application_id: str = None,
+    sub_criteria_id: str = None,
+    theme_id: str = None,
+    comment_id: str = None,
 ):
     """_summary_: Get comments from the assessment store
     Args:
@@ -665,6 +668,7 @@ def get_comments(
         "application_id": application_id,
         "sub_criteria_id": sub_criteria_id,
         "theme_id": theme_id,
+        "comment_id": comment_id,
     }
     # Strip theme_id from dict if None
     query_params_strip_nones = {

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -438,6 +438,20 @@ class TestAuthorisation:
                 assert "Edit comment" in comment_str
                 assert "See history" not in comment_str
 
+        # Assert contents in comments history page
+        response = flask_test_client.get(
+            f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}?comment_id=test_id_1&show_comment_history=1",  # noqa
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"Comment edit history" in response.data
+        assert b"Original comment" in response.data
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        all_comments_history = soup.find_all("div", class_="comment-group")
+        assert "This is comment has history" in str(all_comments_history[0])
+        assert "This is old comment" in str(all_comments_history[1])
+
     @pytest.mark.parametrize(
         "claim",
         [

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -430,7 +430,7 @@ class TestAuthorisation:
         for comment in all_comments:
             comment_str = str(comment)
             # "Edit comment" button is available only for the comment owner
-            # "See history" button is available only for the comment owner and when history available
+            # "See history" button is available for other users(min assessor level) also when history is available
             if "This is comment has history" in comment_str:
                 assert "Edit comment" in comment_str
                 assert "See history" in comment_str


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3731

### Change description
* Added `See History` button (available for comment owner & other assessor role users when history is available  )
* `See History` is available for all roles (`Commenter`, `Assessors` & `Lead Assessors`)

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/c1bf2496-7e20-4beb-ac75-768b15dc000e)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/bb2e2b5c-4ab1-4ab4-ac92-af1efd0789bb)

