### PR TITLE
FS-3752: Hide total funding requested for DPIF

### DIFF
--- a/app/blueprints/assessments/templates/assessor_tasklist.html
+++ b/app/blueprints/assessments/templates/assessor_tasklist.html
@@ -29,6 +29,7 @@
 
     {{ banner_summary(
         state.fund_name,
+        state.fund_short_name,
         state.short_id,
         state.project_name,
         state.funding_amount_requested,

--- a/app/templates/components/header.html
+++ b/app/templates/components/header.html
@@ -14,6 +14,7 @@
 
     {{ banner_summary(
         (state.fund_name if state else fund.name),
+        state.fund_short_name,
         sub_criteria.short_id if sub_criteria else state.short_id,
         sub_criteria.project_name if sub_criteria else state.project_name,
         sub_criteria.funding_amount_requested if sub_criteria else state.funding_amount_requested,

--- a/app/templates/macros/banner_summary.html
+++ b/app/templates/macros/banner_summary.html
@@ -1,4 +1,4 @@
-{% macro banner_summary(fund_name, project_reference, project_name, funding_amount_requested, assessment_status, flag_status) %}
+{% macro banner_summary(fund_name, fund_shortname, project_reference, project_name, funding_amount_requested, assessment_status, flag_status) %}
 <div class="fsd-banner-background">
 <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -7,7 +7,10 @@
                     <p class="govuk-heading-xl fsd-banner-content">Fund: <span class="govuk-!-font-weight-regular">{{ fund_name }}</span></p>
                     <p class="govuk-heading-l fsd-banner-content">Project reference: <span class="govuk-!-font-weight-regular">{{ project_reference | format_project_ref }}</span></p>
                     <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">Project name: {{ project_name }}</p>
-                    <p class="govuk-body-l fsd-banner-content ">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</p>
+
+                    {% if fund_shortname not in ("DPIF",) %} {# Funds that should hide total funding requested. #}
+                        <p class="govuk-body-l fsd-banner-content ">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</p>
+                    {% endif %}
 
                     {% if g.access_controller.has_any_assessor_role %}
                         <p><strong class="govuk-tag govuk-tag--grey govuk-!-margin-top-4">{{ assessment_status }}</strong>

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -630,7 +630,16 @@ class TestJinjaMacros(object):
 
         assert expected_unique_id in rendered_html, "Unique ID not found"
 
-    def test_banner_summary_macro(self, request_ctx):
+    @pytest.mark.parametrize(
+        "fund_short_name, show_funding_amount_requested",
+        [
+            ("TFID", True),
+            ("DPIF", False),
+        ],
+    )
+    def test_banner_summary_macro(
+        self, request_ctx, fund_short_name, show_funding_amount_requested
+    ):
         fund_name = "Test Fund"
         project_reference = "TEST123"
         project_name = "Test Project"
@@ -639,12 +648,14 @@ class TestJinjaMacros(object):
         flag_status = "Flagged"
 
         rendered_html = render_template_string(
-            "{{ banner_summary(fund_name, project_reference, project_name,"
-            " funding_amount_requested, assessment_status, flag_status) }}",
+            "{{ banner_summary(fund_name, fund_short_name, project_reference,"
+            " project_name, funding_amount_requested, assessment_status,"
+            " flag_status) }}",
             banner_summary=get_template_attribute(
                 "macros/banner_summary.html", "banner_summary"
             ),
             fund_name=fund_name,
+            fund_short_name=fund_short_name,
             project_reference=project_reference,
             project_name=project_name,
             funding_amount_requested=funding_amount_requested,
@@ -674,11 +685,17 @@ class TestJinjaMacros(object):
             ),
             text="Project name: Test Project",
         ), "Project name not found"
-        assert soup.find(
+
+        funding_amount_requested_element = soup.find(
             "p",
             class_="govuk-body-l fsd-banner-content",
             text="Total funding requested: £123,456.78",
-        ), "Funding amount not found"
+        )
+        if show_funding_amount_requested:
+            assert funding_amount_requested_element, "Funding amount not found"
+        else:
+            assert not funding_amount_requested_element, "Funding amount found"
+
         assert soup.find(
             "strong",
             class_="govuk-tag",
@@ -690,6 +707,7 @@ class TestJinjaMacros(object):
 
     def test_stopped_flag_macro(self, request_ctx):
         fund_name = "Test Fund"
+        fund_short_name = "TFID"
         project_reference = "TEST123"
         project_name = "Test Project"
         funding_amount_requested = 123456.78
@@ -697,12 +715,14 @@ class TestJinjaMacros(object):
         flag_status = "Stopped"
 
         rendered_html = render_template_string(
-            "{{ banner_summary(fund_name, project_reference, project_name,"
-            " funding_amount_requested, assessment_status, flag_status) }}",
+            "{{ banner_summary(fund_name, fund_short_name, project_reference,"
+            " project_name, funding_amount_requested, assessment_status,"
+            " flag_status) }}",
             banner_summary=get_template_attribute(
                 "macros/banner_summary.html", "banner_summary"
             ),
             fund_name=fund_name,
+            fund_short_name=fund_short_name,
             project_reference=project_reference,
             project_name=project_name,
             funding_amount_requested=funding_amount_requested,


### PR DESCRIPTION
### Change description

- DPIF doesn't have total funding requested, so we should hide it on assessment front-end
- I was thinking of putting this in fund-store, but its assessment specific, so figured have it here

---


- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines


### How to test

- Check out branch, check DPIF assessment on assessment front-end
- Check other fund assessment, observe it still shows properly
- Unit tests also updated accordingly

### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/117724519/8726685b-f042-4929-b888-723197421254)


