### PR TITLE
FS-3842 - Score history not displaying bug fix

### DIFF
--- a/app/blueprints/scoring/templates/macros/scores_justification.html
+++ b/app/blueprints/scoring/templates/macros/scores_justification.html
@@ -2,7 +2,7 @@
 {% from "macros/justification.html" import justification %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro scores_justification(score_form, rescore_form, is_rescore, latest_score, application_id, sub_criteria_id, round_guidance_url) %}
+{% macro scores_justification(score_form, rescore_form, is_rescore, latest_score, application_id, sub_criteria_id, round_guidance_url, score_list) %}
 
 <div class="govuk-grid-column-full s26-scoring">
     {% if latest_score %}
@@ -21,7 +21,7 @@
             <p class="govuk-body-s"> <strong>Date/time:</strong> {{ latest_score.date_created|utc_to_bst }}</p>
         </div>
     </div>
-    {% if score_form.score_list %}
+    {% if score_list %}
     <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
@@ -30,7 +30,7 @@
         </summary>
         <div class="govuk-details__text">
           <div id="anchor">
-            {% for score in score_form.score_list %}
+            {% for score in score_list %}
             <p><strong>Score: </strong>{{ score["score"] }}</p>
             <p><strong>Rationale: </strong>{{ score["justification"] }}</p>
             <p class="govuk-body-s"><strong>{{ score["user_full_name"] }}: </strong> {{ score["highest_role"]|all_caps_to_human }}, {{ score["user_email"] }}</p>

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -52,7 +52,7 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
         </div>
         <div class="theme govuk-grid-column-two-thirds">
             {{ scores_justification(score_form, rescore_form, is_rescore, latest_score, application_id,
-            sub_criteria.id,state.fund_guidance_url) }}
+            sub_criteria.id,state.fund_guidance_url, score_list) }}
             {{ comment_summary(comments, sub_criteria.themes) }}
         </div>
 </div>


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3842

### Change description
Fixing a issue that caused the score history to no longer display

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Score and then rescore a sub criteria and see if the history displays


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/97108643/29ef3f23-3707-46b3-96c6-881210f7f4aa)
