### PR TITLE
FS-3804 add maintainence route

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -33,6 +33,10 @@ def forbidden(error):
     )
 
 
+def error_503(error):
+    return render_template("maintenance.html"), 503
+
+
 @assessment_bp.errorhandler(500)
 @assessment_bp.errorhandler(Exception)
 @shared_bp.errorhandler(500)

--- a/app/templates/maintenance.html
+++ b/app/templates/maintenance.html
@@ -13,7 +13,7 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
           <p class="govuk-body">We are carrying out essential maintenance to the funding assessment tool.</p>
-          <p class="govuk-body">You will be able to use the service again on 18&nbsp;December&nbsp;2023 at 03:00pm.</p>
+          <p class="govuk-body">You will be able to use the service again {{ "on "+ maintenance_end_time if maintenance_end_time else "soon" }}.</p>
           <p class="govuk-body">
             <a class="govuk-link" href="mailto:fsd.support@levellingup.gov.uk">Contact the Funding Service Design team</a> if you need urgent support during this time.
           </p>

--- a/app/templates/maintenance.html
+++ b/app/templates/maintenance.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block pageTitle %}Sorry, the service is unavailable – {{ service_title }}{% endblock pageTitle %}
+{% block pageTitle %}Sorry, this service is unavailable – {{ service_title }}{% endblock pageTitle %}
 
 {% block content %}
     {# djlint:off #}</div>{# djlint:on #}
@@ -11,7 +11,7 @@
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+          <h1 class="govuk-heading-l">Sorry, this service is unavailable</h1>
           <p class="govuk-body">We are carrying out essential maintenance to the funding assessment tool.</p>
           <p class="govuk-body">You will be able to use the service again {{ "on "+ maintenance_end_time if maintenance_end_time else "soon" }}.</p>
           <p class="govuk-body">

--- a/app/templates/maintenance.html
+++ b/app/templates/maintenance.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block pageTitle %}Sorry, the service is unavailable – {{ service_title }}{% endblock pageTitle %}
+
+{% block content %}
+    {# djlint:off #}</div>{# djlint:on #}
+    <div class="fsd-login-banner-background">
+    </div>
+
+    <div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+          <p class="govuk-body">We are carrying out essential maintenance to the funding assessment tool.</p>
+          <p class="govuk-body">You will be able to use the service again on 18&nbsp;December&nbsp;2023 at 03:00pm.</p>
+          <p class="govuk-body">
+            <a class="govuk-link" href="mailto:fsd.support@levellingup.gov.uk">Contact the Funding Service Design team</a> if you need urgent support during this time.
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock content %}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -21,6 +21,7 @@ class DefaultConfig:
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = CommonConfig.FLASK_ENV
     TEXT_AREA_INPUT_MAX_CHARACTERS = 10000
+    MAINTENANCE_MODE = strtobool(getenv("MAINTENANCE_MODE", "True"))
 
     # Authentication
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -22,6 +22,9 @@ class DefaultConfig:
     FLASK_ENV = CommonConfig.FLASK_ENV
     TEXT_AREA_INPUT_MAX_CHARACTERS = 10000
     MAINTENANCE_MODE = strtobool(getenv("MAINTENANCE_MODE", "True"))
+    MAINTENANCE_END_TIME = getenv(
+        "MAINTENANCE_END_TIME", "18 December 2023 at 03:00pm"
+    )
 
     # Authentication
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -21,7 +21,7 @@ class DefaultConfig:
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = CommonConfig.FLASK_ENV
     TEXT_AREA_INPUT_MAX_CHARACTERS = 10000
-    MAINTENANCE_MODE = strtobool(getenv("MAINTENANCE_MODE", "True"))
+    MAINTENANCE_MODE = strtobool(getenv("MAINTENANCE_MODE", "False"))
     MAINTENANCE_END_TIME = getenv(
         "MAINTENANCE_END_TIME", "18 December 2023 at 03:00pm"
     )

--- a/create_app.py
+++ b/create_app.py
@@ -24,6 +24,8 @@ from app.error_handlers import not_found
 from config import Config
 from flask import Flask
 from flask import g
+from flask import render_template
+from flask import request
 from flask_assets import Environment
 from flask_compress import Compress
 from flask_talisman import Talisman
@@ -149,6 +151,13 @@ def create_app() -> Flask:
                 minimum_roles_required=["COMMENTER"],
                 unprotected_routes=["/", "/healthcheck"],
             )
+
+        @flask_app.before_request
+        def check_for_maintenance():
+            if flask_app.config.get(
+                "MAINTENANCE_MODE"
+            ) and not request.path.startswith("/maintenance"):
+                return render_template("maintenance.html"), 503
 
         # Get static filenames list
         static_files_list = []

--- a/create_app.py
+++ b/create_app.py
@@ -146,14 +146,6 @@ def create_app() -> Flask:
         health.add_check(FlaskRunningChecker())
 
         @flask_app.before_request
-        @login_requested
-        def ensure_minimum_required_roles():
-            return auth_protect(
-                minimum_roles_required=["COMMENTER"],
-                unprotected_routes=["/", "/healthcheck"],
-            )
-
-        @flask_app.before_request
         def check_for_maintenance():
             if flask_app.config.get("MAINTENANCE_MODE"):
                 return (
@@ -165,6 +157,14 @@ def create_app() -> Flask:
                     ),
                     503,
                 )
+
+        @flask_app.before_request
+        @login_requested
+        def ensure_minimum_required_roles():
+            return auth_protect(
+                minimum_roles_required=["COMMENTER"],
+                unprotected_routes=["/", "/healthcheck"],
+            )
 
         # Get static filenames list
         static_files_list = []

--- a/create_app.py
+++ b/create_app.py
@@ -156,7 +156,15 @@ def create_app() -> Flask:
         @flask_app.before_request
         def check_for_maintenance():
             if flask_app.config.get("MAINTENANCE_MODE"):
-                return render_template("maintenance.html"), 503
+                return (
+                    render_template(
+                        "maintenance.html",
+                        maintenance_end_time=flask_app.config.get(
+                            "MAINTENANCE_END_TIME"
+                        ),
+                    ),
+                    503,
+                )
 
         # Get static filenames list
         static_files_list = []

--- a/create_app.py
+++ b/create_app.py
@@ -18,6 +18,7 @@ from app.blueprints.shared.filters import slash_separated_day_month_year
 from app.blueprints.shared.filters import utc_to_bst
 from app.blueprints.shared.routes import shared_bp
 from app.blueprints.tagging.routes import tagging_bp
+from app.error_handlers import error_503
 from app.error_handlers import forbidden
 from app.error_handlers import internal_server_error
 from app.error_handlers import not_found
@@ -25,7 +26,6 @@ from config import Config
 from flask import Flask
 from flask import g
 from flask import render_template
-from flask import request
 from flask_assets import Environment
 from flask_compress import Compress
 from flask_talisman import Talisman
@@ -58,6 +58,7 @@ def create_app() -> Flask:
 
         flask_app.register_error_handler(404, not_found)
         flask_app.register_error_handler(403, forbidden)
+        flask_app.register_error_handler(503, error_503)
         flask_app.register_error_handler(500, internal_server_error)
         flask_app.register_blueprint(shared_bp)
         flask_app.register_blueprint(assessment_bp)
@@ -154,9 +155,7 @@ def create_app() -> Flask:
 
         @flask_app.before_request
         def check_for_maintenance():
-            if flask_app.config.get(
-                "MAINTENANCE_MODE"
-            ) and not request.path.startswith("/maintenance"):
+            if flask_app.config.get("MAINTENANCE_MODE"):
                 return render_template("maintenance.html"), 503
 
         # Get static filenames list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from app.blueprints.tagging.models.tag import Tag
 from app.blueprints.tagging.models.tag import TagType
 from config import Config
 from create_app import create_app
+from distutils.util import strtobool
 from flask import template_rendered
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -227,6 +228,26 @@ def flask_test_client(app, user_token=None):
     from our app, this is a test fixture.
     :return: A flask test client.
     """
+    with app.test_client() as test_client:
+        test_client.set_cookie(
+            "localhost",
+            "fsd_user_token",
+            user_token or create_valid_token(),
+        )
+        yield test_client
+
+
+@pytest.fixture(scope="function")
+def flask_test_maintenance_client(request, user_token=None):
+    """
+    Creates the test maintenance client we will be using to test the responses
+    from our app, this is a test fixture.
+    :return: A flask test client.
+    """
+    marker = request.node.get_closest_marker("maintenance_mode")
+    maintenance_mode = marker.args[0]
+    app = create_app()
+    app.config.update({"MAINTENANCE_MODE": strtobool(maintenance_mode)})
     with app.test_client() as test_client:
         test_client.set_cookie(
             "localhost",

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -37,7 +37,6 @@ def test_route_landing_maintenance_mode_disabled(
 @pytest.mark.maintenance_mode("True")
 def test_route_landing_maintenance_mode_enabled(
     flask_test_maintenance_client,
-    mock_get_funds,
 ):
     response = flask_test_maintenance_client.get(
         "/assess/assessor_tool_dashboard/"
@@ -46,7 +45,7 @@ def test_route_landing_maintenance_mode_enabled(
     soup = BeautifulSoup(response.data, "html.parser")
     assert (
         soup.title.string
-        == "Sorry, the service is unavailable – Assessment Hub – GOV.UK"
+        == "Sorry, this service is unavailable – Assessment Hub – GOV.UK"
     ), "Response does not contain expected heading"
 
 
@@ -112,7 +111,6 @@ def test_route_fund_dashboard_maintenance_mode_disabled(
 def test_route_fund_dashboard_maintenance_mode_enabled(
     request,
     flask_test_maintenance_client,
-    mock_get_funds,
 ):
     flask_test_maintenance_client.set_cookie(
         "localhost",
@@ -133,5 +131,5 @@ def test_route_fund_dashboard_maintenance_mode_enabled(
     soup = BeautifulSoup(response.data, "html.parser")
     assert (
         soup.title.string
-        == "Sorry, the service is unavailable – Assessment Hub – GOV.UK"
+        == "Sorry, this service is unavailable – Assessment Hub – GOV.UK"
     ), "Response does not contain expected heading"

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,137 @@
+import pytest
+from bs4 import BeautifulSoup
+from tests.conftest import create_valid_token
+from tests.conftest import fund_specific_claim_map
+
+
+@pytest.mark.mock_parameters(
+    {
+        "get_assessment_stats_path": [
+            "app.blueprints.assessments.models.fund_summary.get_assessments_stats",
+        ],
+        "get_rounds_path": [
+            "app.blueprints.assessments.models.fund_summary.get_rounds",
+        ],
+        "fund_id": "test-fund",
+        "round_id": "test-round",
+    }
+)
+@pytest.mark.maintenance_mode("False")
+def test_route_landing_maintenance_mode_disabled(
+    flask_test_maintenance_client,
+    mock_get_funds,
+    mock_get_rounds,
+    mock_get_assessment_stats,
+):
+    response = flask_test_maintenance_client.get(
+        "/assess/assessor_tool_dashboard/"
+    )
+    assert 200 == response.status_code, "Wrong status code on response"
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert (
+        soup.title.string
+        == "Assessment tool dashboard – Assessment Hub – GOV.UK"
+    ), "Response does not contain expected heading"
+
+
+@pytest.mark.maintenance_mode("True")
+def test_route_landing_maintenance_mode_enabled(
+    flask_test_maintenance_client,
+    mock_get_funds,
+):
+    response = flask_test_maintenance_client.get(
+        "/assess/assessor_tool_dashboard/"
+    )
+    assert 503 == response.status_code, "Wrong status code on response"
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert (
+        soup.title.string
+        == "Sorry, the service is unavailable – Assessment Hub – GOV.UK"
+    ), "Response does not contain expected heading"
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": {
+            "search_term": "",
+            "search_in": "project_name,short_id",
+            "asset_type": "ALL",
+            "status": "ALL",
+            "filter_by_tag": "ALL",
+            "local_authority": "ALL",
+            "country": "ALL",
+            "region": "ALL",
+        },
+    }
+)
+@pytest.mark.application_id("resolved_app")
+@pytest.mark.maintenance_mode("False")
+def test_route_fund_dashboard_maintenance_mode_disabled(
+    request,
+    flask_test_maintenance_client,
+    mock_get_fund,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_application_overviews,
+    mock_get_assessment_progress,
+    mock_get_active_tags_for_fund_round,
+    mock_get_tag_types,
+):
+    flask_test_maintenance_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map["COF"]["ASSESSOR"]),
+    )
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    response = flask_test_maintenance_client.get(
+        f"/assess/assessor_dashboard/{fund_short_name}/{round_short_name}",
+        follow_redirects=True,
+    )
+    assert 200 == response.status_code, "Wrong status code on response"
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert (
+        soup.title.string == "Team dashboard – Assessment Hub – GOV.UK"
+    ), "Response does not contain expected heading"
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+    }
+)
+@pytest.mark.application_id("resolved_app")
+@pytest.mark.maintenance_mode("True")
+def test_route_fund_dashboard_maintenance_mode_enabled(
+    request,
+    flask_test_maintenance_client,
+    mock_get_funds,
+):
+    flask_test_maintenance_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map["COF"]["ASSESSOR"]),
+    )
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    response = flask_test_maintenance_client.get(
+        f"/assess/assessor_dashboard/{fund_short_name}/{round_short_name}",
+        follow_redirects=True,
+    )
+    assert 503 == response.status_code, "Wrong status code on response"
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert (
+        soup.title.string
+        == "Sorry, the service is unavailable – Assessment Hub – GOV.UK"
+    ), "Response does not contain expected heading"


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3804

### Description
Added maintenance mode var in config, if enabled `Service unavailable` page is displayed on all routes

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
set the var `MAINTENANCE_MODE` to True and visit any assessment route page. Observe the maintenance page being displayed 

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/28e77b9b-11c7-4515-83e7-6f06eb3dc95c)

