### PR TITLE
FS-3834 display assessment status in activity page

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -23,6 +23,7 @@ from app.blueprints.assessments.forms.comments_form import CommentsForm
 from app.blueprints.assessments.forms.mark_qa_complete_form import (
     MarkQaCompleteForm,
 )
+from app.blueprints.assessments.helpers import determine_display_status
 from app.blueprints.assessments.helpers import download_file
 from app.blueprints.assessments.helpers import generate_assessment_info_csv
 from app.blueprints.assessments.helpers import generate_maps_from_form_names
@@ -773,6 +774,12 @@ def activity_trail(application_id: str):
         update_user_info, search_keyword, checkbox_filters
     )
 
+    display_status = determine_display_status(
+        state.workflow_status,
+        flags_list,
+        state.is_qa_complete,
+    )
+
     return render_template(
         "activity_trail.html",
         application_id=application_id,
@@ -784,6 +791,7 @@ def activity_trail(application_id: str):
         search_keyword=search_keyword,
         checkbox_filters=checkbox_filters,
         migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
+        display_status=display_status,
     )
 
 

--- a/app/blueprints/assessments/templates/activity_trail.html
+++ b/app/blueprints/assessments/templates/activity_trail.html
@@ -50,15 +50,6 @@
 
 {% block content %}
 
-{% set tag_color = 'not-started-tag' if state.workflow_status == 'NOT_STARTED' else state.workflow_status
-%}
-
-{# this logic may need to be moved to python when the workflow status and flag status mechanism is sorted #}
-{% set status = state.workflow_status|remove_dashes_underscores_capitalize|title %}
-{% set display_workflow_status = "Assessment complete" if status=="Completed" and not state.is_qa_complete
-else "QA complete" if status=="Completed" and state.is_qa_complete
-else status %}
-
 <main class="govuk-main-wrapper" id="main-content" role="main">
     {% if migration_banner_enabled %}
     {{migration_banner()}}
@@ -67,8 +58,39 @@ else status %}
         <div>
             <div class="govuk-!-padding-left-3">
                 <h1 class="govuk-heading-l">Activity trail</h1>
-                <p class="govuk-body">Current assessment status: <span
-                        class="{{tag_color}} govuk-body">{{display_workflow_status }}</span></p>
+                <p class="govuk-body">Current assessment status:
+                {% if display_status == "QA complete" %}
+                <span>{{ display_status }}</span>
+                {% elif display_status == "Stopped" %}
+                <span class="stopped-tag">
+                    {{ display_status }}
+                </span>
+                {% elif display_status == "Flagged" %}
+                <span class="flagged-tag">
+                    {{ display_status }}
+                </span>
+                {% elif "Flagged" in display_status %}
+                <span class="flagged-tag">
+                    {{ display_status }}
+                </span>
+                {% elif display_status == "Not started" %}
+                <span class="not-started-tag">
+                    {{ display_status }}
+                </span>
+                {% elif display_status == "Assessment complete" %}
+                <span>
+                    {{ display_status }}
+                </span>
+                {% elif display_status == "Multiple flags to resolve" %}
+                <span class="flagged-tag">
+                    {{ display_status }}
+                </span>
+                {% else %}
+                <span>
+                    {{ display_status }}
+                </span>
+                {% endif %}
+                </p>
             </div>
 
 

--- a/app/blueprints/assessments/templates/activity_trail.html
+++ b/app/blueprints/assessments/templates/activity_trail.html
@@ -59,36 +59,22 @@
             <div class="govuk-!-padding-left-3">
                 <h1 class="govuk-heading-l">Activity trail</h1>
                 <p class="govuk-body">Current assessment status:
-                {% if display_status == "QA complete" %}
-                <span>{{ display_status }}</span>
-                {% elif display_status == "Stopped" %}
-                <span class="stopped-tag">
-                    {{ display_status }}
-                </span>
-                {% elif display_status == "Flagged" %}
-                <span class="flagged-tag">
-                    {{ display_status }}
-                </span>
-                {% elif "Flagged" in display_status %}
-                <span class="flagged-tag">
-                    {{ display_status }}
-                </span>
+                {% if display_status == "Stopped" %}
+                    <span class="stopped-tag">
+                        {{ display_status }}
+                    </span>
+                {% elif ("Flagged" in display_status) or (display_status in ("Flagged", "Multiple flags to resolve")) %}
+                    <span class="flagged-tag">
+                        {{ display_status }}
+                    </span>
                 {% elif display_status == "Not started" %}
-                <span class="not-started-tag">
-                    {{ display_status }}
-                </span>
-                {% elif display_status == "Assessment complete" %}
-                <span>
-                    {{ display_status }}
-                </span>
-                {% elif display_status == "Multiple flags to resolve" %}
-                <span class="flagged-tag">
-                    {{ display_status }}
-                </span>
+                    <span class="not-started-tag">
+                        {{ display_status }}
+                    </span>
                 {% else %}
-                <span>
-                    {{ display_status }}
-                </span>
+                    <span>
+                        {{ display_status }}
+                    </span>
                 {% endif %}
                 </p>
             </div>


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3834

### Description
display assessment status (same logic from the assessment list page) in the activity trail page

### Screenshots of UI changes (if applicable)
**Scenario** : Flagged
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/ac400b12-69fb-41c6-8b86-d594416cf901)

**Scenario**: Not started

![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/cfe3ca2e-f5ff-4707-9bb9-92912f582d4b)

