### PR TITLE
Refactor(theme answers): Consolidate logic into frontend [FS-4046]

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -94,7 +94,7 @@ from app.blueprints.services.data_services import get_round
 from app.blueprints.services.data_services import get_score_and_justification
 from app.blueprints.services.data_services import get_sub_criteria
 from app.blueprints.services.data_services import (
-    get_sub_criteria_theme_answers,
+    get_sub_criteria_theme_answers_all,
 )
 from app.blueprints.services.data_services import get_tags_for_fund_round
 from app.blueprints.services.data_services import match_comment_to_theme
@@ -497,7 +497,7 @@ def display_sub_criteria(
         "assessment_status": assessment_status,
     }
 
-    theme_answers_response = get_sub_criteria_theme_answers(
+    theme_answers_response = get_sub_criteria_theme_answers_all(
         application_id, theme_id
     )
 

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -20,6 +20,9 @@ from app.blueprints.services.models.sub_criteria import SubCriteria
 from app.blueprints.tagging.models.tag import AssociatedTag
 from app.blueprints.tagging.models.tag import Tag
 from app.blueprints.tagging.models.tag import TagType
+from app.blueprints.themes.deprecated_theme_mapper import (
+    map_application_with_sub_criteria_themes_fields,
+)
 from config import Config
 from flask import abort
 from flask import current_app
@@ -625,43 +628,26 @@ def submit_flag(
 def get_all_uploaded_documents_theme_answers(
     application_id: str,
 ) -> Union[list, None]:
-    all_uploaded_documents_theme_answers_endpoint = (
-        Config.ALL_UPLOADED_DOCUMENTS_THEME_ANSWERS_ENDPOINT.format(
-            application_id=application_id
-        )
-    )
-    all_uploaded_documents_theme_answers_response = get_data(
-        all_uploaded_documents_theme_answers_endpoint
+    return get_sub_criteria_theme_answers_all(
+        application_id,
+        "all_uploaded_documents",
     )
 
-    if isinstance(all_uploaded_documents_theme_answers_response, list):
-        return all_uploaded_documents_theme_answers_response
-    else:
-        msg = (
-            f"all_uploaded_documents_theme_answers: '{application_id}' not"
-            " found."
-        )
-        current_app.logger.warn(msg)
-        abort(404, description=msg)
 
-
-def get_sub_criteria_theme_answers(
-    application_id: str, theme_id: str
+def get_sub_criteria_theme_answers_all(
+    application_id: str,
+    theme_id: str,
 ) -> Union[list, None]:
-    theme_answers_endpoint = (
-        Config.ASSESSMENT_STORE_API_HOST
-        + Config.SUB_CRITERIA_THEME_ANSWERS_ENDPOINT.format(
-            application_id=application_id, theme_id=theme_id
-        )
+    theme_mapping_data_url = (
+        f"{Config.ASSESSMENT_STORE_API_HOST}"
+        f"{Config.SUB_CRITERIA_THEME_ANSWERS_ENDPOINT.format(application_id=application_id)}"
     )
-    theme_answers_response = get_data(theme_answers_endpoint)
-
-    if theme_answers_response:
-        return theme_answers_response
-    else:
-        msg = f"theme_answers: '{theme_id}' not found."
-        current_app.logger.warn(msg)
-        abort(404, description=msg)
+    theme_mapping_data = get_data(theme_mapping_data_url)
+    return map_application_with_sub_criteria_themes_fields(
+        theme_mapping_data["application_json"],
+        theme_mapping_data["sub_criterias"],
+        theme_id,
+    )
 
 
 def get_comments(

--- a/app/blueprints/themes/deprecated_theme_mapper.py
+++ b/app/blueprints/themes/deprecated_theme_mapper.py
@@ -1,0 +1,247 @@
+from collections import defaultdict
+from typing import Any
+
+from flask import current_app
+
+
+# This code was copied directly from the assessments store in an attempt to consolidate all the transformation logic
+# in one place. The goal of putting all the transformation logic in one place is so that we can eventually refactor
+# it to be less complex and more simplified. There's a lot of complicated nuance that realistically doesn't need to
+# exist, so this is the first step in removing it. Therefore, all the code that you see below is copied directly from
+# assessments store and not uniquely written at the time of this commit.
+def map_application_with_sub_criteria_themes_fields(
+    application_json,
+    sub_criterias,
+    theme_id,
+):
+    questions = [
+        questions
+        for forms in application_json["jsonb_blob"]["forms"]
+        for questions in forms["questions"]
+    ]
+    themes_fields = get_themes_fields(
+        sub_criterias,
+        theme_id,
+    )
+    for theme in themes_fields:
+        try:
+            if isinstance(theme["field_id"], list):
+                map_grouped_fields_answers(theme, questions)
+            else:
+                map_single_field_answer(theme, questions)
+        except TypeError:
+            current_app.logger.error(f"Incorrect theme id -> {theme_id}")
+            return f"Incorrect theme id -> {theme_id}"
+
+    convert_boolean_values(themes_fields)
+
+    # Does not sort on the new version of add-another simply pass the object through for display by assessment frontend
+    # the old version of add-another which was not scalable and did not allow the adding of N* fields
+    deprecated_sort_add_another_component_contents(themes_fields)
+
+    return format_add_another_component_contents(themes_fields)
+
+
+def get_themes_fields(sub_criterias, theme_id) -> str | Any:
+    if theme_id == "all_uploaded_documents":
+        return [
+            {
+                **answer,
+                "question": f"{theme['name']}, {answer['question']}",
+                "form_name": answer["form_name"],
+            }
+            for item in sub_criterias
+            for theme in item["themes"]
+            for answer in theme["answers"]
+            if answer["field_type"]
+            in ["clientSideFileUploadField", "fileUploadField"]
+        ]
+    else:
+        try:
+            return [
+                theme.get("answers")
+                for themes in sub_criterias
+                for theme in themes.get("themes")
+                if theme_id == theme.get("id")
+            ][0]
+        except IndexError:
+            current_app.logger.error(f"Incorrect theme id -> {theme_id}")
+            return f"Incorrect theme id -> {theme_id}"
+
+
+def map_grouped_fields_answers(theme, questions):
+    for question in questions:
+        answer_list = tuple(
+            (
+                (app["title"], app["answer"])
+                for app in question["fields"]
+                for field_id in theme["field_id"]
+                if "answer" in app.keys() and app["key"] == field_id
+            )
+        )
+        if answer_list:
+            theme["answer"] = answer_list
+
+
+def map_single_field_answer(theme, questions):
+    for question in questions:
+        for app_fields in question["fields"]:
+            if (
+                theme["field_id"] == app_fields["key"]
+                and "answer" in app_fields.keys()
+            ):
+                # Some fields are optional so will have no answers
+                theme["answer"] = app_fields.get("answer", None)
+
+
+def convert_boolean_values(themes_fields) -> None:
+    current_app.logger.info("Converting boolean values to strings")
+    for field in themes_fields:
+        if "answer" not in field.keys():
+            continue
+        elif field["answer"] is False:
+            field.update(answer="No")
+        elif field["answer"] is True:
+            field.update(answer="Yes")
+
+
+# supports the old version of add-another which was
+# not scalable and did not allow the adding of N* fields
+def deprecated_sort_add_another_component_contents(
+    themes_fields: list[dict],
+) -> None:
+    for field in themes_fields:
+        try:
+            if field["presentation_type"] != "heading":
+                continue
+
+            field["answer"] = field["question"]
+            for theme in themes_fields:
+                if not field["field_id"] in theme.values():
+                    continue
+
+                if theme["presentation_type"] == "description":
+                    description_answer = [
+                        description.rsplit(": ", 1)[0]
+                        for description in theme["answer"]
+                    ]
+                    theme["answer"] = description_answer
+
+                if theme["presentation_type"] == "amount":
+                    amount_answer = [
+                        amount.rsplit(": ", 1)[1] for amount in theme["answer"]
+                    ]
+                    theme["answer"] = amount_answer
+        except (KeyError, IndexError):
+            current_app.logger.debug(
+                f"Answer not provided for field_id: {field['field_id']}"
+            )
+
+
+def format_add_another_component_contents(
+    themes_fields: list[dict],
+) -> list[dict]:
+    for field in themes_fields:
+        if field.get("presentation_type") != "table":
+            continue
+
+        title, table_config = field["question"]
+        field["question"] = title
+
+        component_id_to_answer_list = {}
+        # In some cases (optional or path based questions) there is no answer provided
+        for answer_container in field.get("answer", []):
+            for component_id, answer in answer_container.items():
+                if component_id not in component_id_to_answer_list:
+                    component_id_to_answer_list[component_id] = []
+                component_id_to_answer_list[component_id].append(answer)
+
+        table = []
+        for component_id, column_config in table_config.items():
+            frontend_format = None
+            title = column_config["column_title"]
+            answers = component_id_to_answer_list.get(component_id)
+
+            # match the field type without case sensitivity
+            for key, value in _MULTI_INPUT_FORMAT_FRONTEND.items():
+                if key.lower() == column_config["type"].lower():
+                    frontend_format = value
+                    break
+            if frontend_format is None:
+                frontend_format = "text"
+
+            pre_frontend_formatter = _MULTI_INPUT_FRE_FRONTEND_FORMATTERS.get(
+                column_config["type"], lambda x: x
+            )
+
+            formatted_answers = (
+                [
+                    (
+                        "Not provided."  # default value, if None or empty string provided
+                        if (answer is None or answer == "")
+                        else pre_frontend_formatter(answer)
+                    )
+                    for answer in answers
+                ]
+                if answers
+                else None
+            )
+
+            if frontend_format == "monthYearField":
+                formatted_answers = (
+                    [
+                        f"{answer[component_id + '__month']}-"
+                        f"{answer[component_id + '__year']}"
+                        for answer in answers
+                    ]
+                    if answers
+                    else None
+                )
+
+            # Manualy extract `ukAddressField` as text if rendered as dict
+            if column_config["type"] == "ukAddressField" and formatted_answers:
+                for ind, answer in enumerate(formatted_answers):
+                    if isinstance(answer, dict):
+                        try:
+                            formatted_answers[ind] = (
+                                answer["addressLine1"]
+                                + ", "
+                                + answer.get("addressLine2", "")
+                                + ", "
+                                + answer["postcode"]
+                                + ", "
+                                + answer.get("county")
+                                + ", "
+                                + answer["town"]
+                            ).replace(" ,", "")
+                        except Exception:
+                            formatted_answers[ind] = ", ".join(
+                                list(filter(None, answer.values()))
+                            )
+
+            if formatted_answers:
+                table.append([title, formatted_answers, frontend_format])
+        field["answer"] = table
+
+    return themes_fields
+
+
+# All in use children of multiInputField in cofr3/nstfr2
+# If we use or add new children, we may need to add support
+_MULTI_INPUT_FORMAT_FRONTEND = defaultdict(
+    lambda: "text",
+    {
+        "numberField": "currency",
+        "multilineTextField": "html",
+        # the default should handle these, but let's be explicit
+        "RadioField": "text",
+        "textField": "text",
+        "MonthYearField": "monthYearField",
+        "yesNoField": "text",
+    },
+)
+
+_MULTI_INPUT_FRE_FRONTEND_FORMATTERS = {
+    "RadioField": lambda x: x.capitalize(),
+    "yesNoField": lambda x: "Yes" if bool(x) else "No",
+}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -140,7 +140,7 @@ class DefaultConfig:
     )
 
     SUB_CRITERIA_THEME_ANSWERS_ENDPOINT = (
-        "/sub_criteria_themes/{application_id}/{theme_id}"
+        "/sub_criteria_themes/{application_id}"
     )
 
     SUB_CRITERIA_OVERVIEW_ENDPOINT = (


### PR DESCRIPTION
Migrated transformation logic for theme answers from the assessment store to the frontend. This centralization supports an upcoming major refactor, reducing complexity by simplifying future modifications. The assessment store now only returns necessary data, streamlining the architecture and making the refactor process more manageable. Functionality verified post-migration.

# Reasons
- Facilitates a cleaner, more efficient refactor.
- Centralizes logic for easier future updates.

# Changes
- Logic moved to frontend; assessment store simplified.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

