### PR TITLE
FS-4219 Enabling assessment view

### DIFF
--- a/app/blueprints/authentication/validation.py
+++ b/app/blueprints/authentication/validation.py
@@ -93,26 +93,41 @@ def has_access_to_fund(short_name: str) -> bool:
     return any(role in all_roles for role in access_roles)
 
 
-def is_assessment_active(fund_id, round_id):
+def has_assessment_opened(fund_id=None, round_id=None, round=None) -> bool:
+    """Determines whether assessment has opened in the past. Overriden by
+    `Config.FORCE_OPEN_ALL_LIVE_ASSESSMENT_ROUNDS` in test envs.
+
+    Does not use `assessment_end_date`. If there is an `assessment_starts` present, uses that, otherwise
+    uses the `deadline` for applications in this round.
+
+    Args:
+        fund_id (_type_, optional): ID of the fund for the round to determine the status for. Defaults to None.
+        round_id (_type_, optional): ID of the round to determine the status for. Defaults to None.
+        round (_type_, optional): A round object - can be provided instead of IDs if already retrieved.
+            Defaults to None.
+
+    Returns:
+        bool: Whether or not this assessment round has opened.
+    """
     from datetime import datetime
 
-    # Check if the application is in a live round
-    round_information = get_round(
-        fund_id,
-        round_id,
-        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
-    )
+    if not round:
+        round = get_round(
+            fund_id,
+            round_id,
+            ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+        )
 
     # Used in test envs to access open rounds
     if Config.FORCE_OPEN_ALL_LIVE_ASSESSMENT_ROUNDS:
         return True
 
-    deadline = datetime.strptime(round_information.deadline, "%Y-%m-%dT%H:%M:%S")
+    deadline = datetime.strptime(round.deadline, "%Y-%m-%dT%H:%M:%S")
     assessment_start = (
-        datetime.strptime(round_information.assessment_start, "%Y-%m-%dT%H:%M:%S")
-        if round_information.assessment_start
-        else None
+        datetime.strptime(round.assessment_start, "%Y-%m-%dT%H:%M:%S") if round.assessment_start else None
     )
+
+    # Not all rounds have an assessment_start specified. If they do not, use the application closing date instead
 
     if assessment_start:
         return datetime.now() > assessment_start
@@ -142,7 +157,7 @@ def check_access_application_id(func: Callable = None, roles_required: List[str]
             ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
         ).short_name
 
-        assessment_open = is_assessment_active(application_metadata["fund_id"], application_metadata["round_id"])
+        assessment_open = has_assessment_opened(application_metadata["fund_id"], application_metadata["round_id"])
         if not assessment_open:
             abort(403, "This assessment is not yet live.")
 
@@ -194,7 +209,7 @@ def _check_access_fund_common(
         )
 
         round_details = get_round(fund_value, round_value, using_short_name)
-        assessment_open = is_assessment_active(round_details.fund_id, round_details.id)
+        assessment_open = has_assessment_opened(round_details.fund_id, round_details.id)
         if not assessment_open:
             abort(403, "This assessment is not yet live.")
 

--- a/app/blueprints/authentication/validation.py
+++ b/app/blueprints/authentication/validation.py
@@ -103,11 +103,21 @@ def is_assessment_active(fund_id, round_id):
         ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
     )
 
-    deadline = datetime.strptime(round_information.deadline, "%Y-%m-%dT%H:%M:%S")
-    if datetime.now() > deadline or Config.FORCE_OPEN_ALL_LIVE_ASSESSMENT_ROUNDS:
+    # Used in test envs to access open rounds
+    if Config.FORCE_OPEN_ALL_LIVE_ASSESSMENT_ROUNDS:
         return True
+
+    deadline = datetime.strptime(round_information.deadline, "%Y-%m-%dT%H:%M:%S")
+    assessment_start = (
+        datetime.strptime(round_information.assessment_start, "%Y-%m-%dT%H:%M:%S")
+        if round_information.assessment_start
+        else None
+    )
+
+    if assessment_start:
+        return datetime.now() > assessment_start
     else:
-        return False
+        return datetime.now() > deadline
 
 
 def check_access_application_id(func: Callable = None, roles_required: List[str] = []) -> Callable:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -200,7 +200,7 @@ def test_check_access_application_id_cant_access_application_when_no_country_rol
         },
     )
     monkeypatch.setattr(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         lambda *args, **kwargs: True,
     )
     monkeypatch.setattr(
@@ -247,7 +247,7 @@ def test_check_access_application_id_can_access_application_when_has_country_rol
         },
     )
     monkeypatch.setattr(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         lambda *args, **kwargs: True,
     )
     monkeypatch.setattr(
@@ -296,7 +296,7 @@ def test_check_access_application_id_can_access_application_when_fund_has_no_dev
         },
     )
     monkeypatch.setattr(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         lambda *args, **kwargs: True,
     )
     monkeypatch.setattr(
@@ -335,7 +335,7 @@ def test_check_access_application_id_cant_access_application_when_no_relevant_fu
         },
     )
     monkeypatch.setattr(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         lambda *args, **kwargs: True,
     )
     monkeypatch.setattr(
@@ -406,7 +406,7 @@ def test_check_access_fund_short_name_round_sn_can_access(monkeypatch, mock_get_
         lambda _: "cof",
     )
     monkeypatch.setattr(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         lambda *args, **kwargs: True,
     )
     monkeypatch.setattr(
@@ -477,7 +477,7 @@ def test_check_access_application_id_decorator_returns_403_for_inactive_assessme
         return_value="test",
     )
     mocker.patch(
-        "app.blueprints.authentication.validation.is_assessment_active",
+        "app.blueprints.authentication.validation.has_assessment_opened",
         return_value=False,
     )
     mocker.patch(


### PR DESCRIPTION
### Change description
Updated the validation on viewing applications in assessment to allow viewing them before the round has closed

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

- Setup EOI so the round is open and so you are within the assessment start/end dates. You will need to set an assessment_start date, so may need to run the data import script on latest fund store.
- Set the env var `FORCE_OPEN_ALL_LIVE_ASSESSMENT_ROUNDS` to `False`
- Navigate to the assessment tool landing page
- You should be able to 'view all active assessments' for EOI


### Screenshots of UI changes (if applicable)
