### PR TITLE
FS-4164-display-export-application-data-button-for-cofeoi

### DIFF
--- a/app/blueprints/assessments/templates/assessor_tasklist.html
+++ b/app/blueprints/assessments/templates/assessor_tasklist.html
@@ -14,6 +14,7 @@
 {% from "macros/qa_complete_flag.html" import qa_complete_flag %}
 {% from "macros/assessment_completion.html" import assessment_complete %}
 {% from "macros/migration_banner.html" import migration_banner %}
+{% from "macros/link_to_download_contract_docs.html" import link_to_download_contract_docs %}
 
 {% set pageHeading = state.project_name %}
 
@@ -102,6 +103,15 @@
         {% endif %}
     </span>
     </div>
+
+    <div class="gov-uk-table__cell--align-right">
+        <span class="left govuk-!-padding-right-4">
+            {% if g.access_controller.is_lead_assessor and state.fund_short_name|upper =="COF-EOI" %}
+            {{ link_to_download_contract_docs(csrf_token, application_id) }}
+        {% endif %}
+        </span>
+
+        </div>
 </div>
 </div>
 {% endif %}

--- a/app/blueprints/assessments/templates/assessor_tasklist.html
+++ b/app/blueprints/assessments/templates/assessor_tasklist.html
@@ -106,11 +106,10 @@
 
     <div class="gov-uk-table__cell--align-right">
         <span class="left govuk-!-padding-right-4">
-            {% if g.access_controller.is_lead_assessor and state.fund_short_name|upper =="COF-EOI" %}
-            {{ link_to_download_contract_docs(csrf_token, application_id) }}
+        {% if g.access_controller.is_lead_assessor and state.fund_short_name|upper =="COF-EOI" %}
+        {{ link_to_download_contract_docs(csrf_token, application_id) }}
         {% endif %}
         </span>
-
         </div>
 </div>
 </div>

--- a/app/blueprints/assessments/templates/assessor_tasklist.html
+++ b/app/blueprints/assessments/templates/assessor_tasklist.html
@@ -110,7 +110,7 @@
         {{ link_to_download_contract_docs(csrf_token, application_id) }}
         {% endif %}
         </span>
-        </div>
+    </div>
 </div>
 </div>
 {% endif %}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4164


Display button Export application data on the assessor task list page when a lead assessor is looged in to the tasklist page



### Screenshots of UI changes
![Screenshot 2024-02-27 at 15 41 51](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/c6e01079-e2d5-4400-a8fb-3166b9f7182e)
