### PR TITLE
FS-4150-display-round-name-along-with-fund-name-to-the-text-file

### DIFF
--- a/app/blueprints/assessments/models/file_factory.py
+++ b/app/blueprints/assessments/models/file_factory.py
@@ -27,7 +27,8 @@ class ApplicationFileRepresentationArgs(NamedTuple):
 
 
 def _generate_text_of_application(args: ApplicationFileRepresentationArgs):
-    text = generate_text_of_application(args.question_to_answer, args.fund.name)
+    fund_round_name = f"{args.fund.name} {args.round.title}"
+    text = generate_text_of_application(args.question_to_answer, fund_round_name)
     return download_file(text, "text/plain", f"{args.short_id}_answers.txt")
 
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4150

Display round name next to the fund name on a text file

### Screenshots of UI changes
![Screenshot 2024-03-01 at 17 39 22](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/087ce339-946e-4aef-ba8a-6a48c8229dc8)
