### PR TITLE
BAU: show submited application link EOI

### DIFF
--- a/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
+++ b/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
@@ -93,7 +93,7 @@
                 })
             }}
             {%endif%}
-            {% if force_open_all_live_assessment_rounds %}
+            {% if force_open_all_live_assessment_rounds or "Expression of interest" in summary.round_name %}
                 <a class="govuk-link" data-qa="dashboard_summary" href="{{ summary.assessments_href }}">
                     View all submitted applications
                 </a>


### PR DESCRIPTION
### Description
Fixed bug - show `View all submited applications` link for COF-EOI

#### Before
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/d3015450-77ea-42e8-81ae-edbcaf4c76a4)


#### After
![image](https://github.com/communitiesuk/funding-service-design-assessment/assets/127315890/345e1341-1450-4ff3-bc1e-1d5d04f66ba4)

