### PR TITLE
FS-4266-cofeoi-assessment-not-filterable-by-fund-type-on-dashboard-page

### DIFF
--- a/app/blueprints/services/models/fund.py
+++ b/app/blueprints/services/models/fund.py
@@ -40,6 +40,8 @@ class Fund:
             return {ALL_VALUE, "competitive"}
         elif self.short_name == "DPIF":
             return {ALL_VALUE, "competitive"}
+        elif self.short_name == "COF-EOI":
+            return {ALL_VALUE, "allocative"}
         return {ALL_VALUE}
 
     def add_round(self, fund_round: Round):


### PR DESCRIPTION
 ### Ticket
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4266

### Description
fix for COF-EOI filter: COF EOI Assessment is not filterable by fund type in "Funding service dashboard" page

### Screenshots of UI changes 
![Screenshot 2024-03-11 at 20 52 52](https://github.com/communitiesuk/funding-service-design-assessment/assets/80714392/73554966-1b92-44e3-ac0b-b7e9f7a6489e)

