### PR TITLE
fs-4303 fixing links

### DIFF
--- a/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
+++ b/app/blueprints/assessments/templates/macros/fund_dashboard_summary.html
@@ -48,7 +48,7 @@ assessment_tracker_href, round_status) %}
                 </br>
             {% endif %}
         {% endif %}
-        {% if assessment_tracker_href  and round_status.has_application_closed %}
+        {% if assessment_tracker_href  and round_status.has_assessment_opened %}
             <a class="govuk-link" href="{{ assessment_tracker_href }}">
                 Assessment Tracker Export
             </a>

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -927,6 +927,7 @@ class TestJinjaMacros(object):
                     "View all active assessments",
                     "Export applicant information",
                     "Export feedback survey responses",
+                    "Assessment Tracker Export",
                 ],
             ),
             (


### PR DESCRIPTION
Updated link display to check whether assessment is open, not whether application has closed for the 'Export Assessment Tracker'