### PR TITLE
FS-4055: Crown logo update assessment

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,6 +1,6 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 
-{% set assetPath = url_for('static', filename='').rstrip('/') %}
+{% set assetPath = '/static/govuk-frontend' %}
 
 {% block pageTitle %}{{ [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title }}{% endblock pageTitle %}
 
@@ -29,7 +29,7 @@
 
 {% block bodyEnd %}
   <!--[if gt IE 8]><!-->
-    <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='govuk-frontend/govuk-frontend-4.7.0.min.js') }}"> </script>
+    <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.3.0.min.js') }}"> </script>
     <script nonce="{{ csp_nonce() }}">
 
       window.addEventListener('load', (event) => {

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -1,8 +1,8 @@
 <meta name="description" content="{{ service_meta_description }}">
 <meta name="keywords" content="{{ service_meta_keywords }}">
 <meta name="author" content="{{ service_meta_author }}">
-<!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-4.7.0.min.css') }}" /><!--<![endif]-->
-<!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-ie8-4.7.0.min.css') }}" /><![endif]-->
+<!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.3.0.min.css') }}" /><!--<![endif]-->
+<!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-ie8-5.3.0.min.css') }}" /><![endif]-->
 {% assets "default_styles" %}
     <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}"><!--<![endif]-->
 {% endassets %}

--- a/build.py
+++ b/build.py
@@ -10,7 +10,7 @@ import static_assets
 def build_govuk_assets(static_dist_root="app/static/dist"):
     DIST_ROOT = "./" + static_dist_root
     GOVUK_DIR = "/govuk-frontend"
-    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.7.0/release-v4.7.0.zip"
+    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v5.3.0/release-v5.3.0.zip"
     ZIP_FILE = "./govuk_frontend.zip"
     DIST_PATH = DIST_ROOT + GOVUK_DIR
     ASSETS_DIR = "/assets"


### PR DESCRIPTION
### Change description

- govuk-fronend version updated to 5.3.0 from 4.7.0 which includes updated crown assets
- updated the assetPath variable to the correct location for assets

### Ticket
https://dluhcdigital.atlassian.net/browse/FS-4055

### How to test
- By going to the assessment endpoint


### Screenshots of UI changes (if applicable)
<img width="979" alt="Screenshot 2024-04-17 at 15 51 57" src="https://github.com/communitiesuk/funding-service-design-assessment/assets/66220499/05690ae9-c922-46de-acdb-d7cd9c2dfaca">
