### PR TITLE
Fs 4411 overprovision instance

### DIFF
--- a/copilot/fsd-assessment/manifest.yml
+++ b/copilot/fsd-assessment/manifest.yml
@@ -70,7 +70,7 @@ environments:
     deployment:
       rolling: 'recreate'
     count: 
-      spot: 1
+      spot: 2
   uat:
     http:
       alias: "assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"

--- a/copilot/fsd-assessment/manifest.yml
+++ b/copilot/fsd-assessment/manifest.yml
@@ -31,7 +31,7 @@ memory: 2048
 # See https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#platform
 platform: linux/x86_64
 # Number of tasks that should be running in your service.
-count: 2
+count: 1
 # Enable running commands in your container.
 exec: true
 
@@ -64,9 +64,13 @@ secrets:
 # You can override any of the values defined above by environment.
 environments:
   dev:
+    count:
+      spot: 1
   test:
     deployment:
       rolling: 'recreate'
+    count: 
+      spot: 1
   uat:
     http:
       alias: "assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"


### PR DESCRIPTION
-FS-4411: Overprovision instance

### Change description

Reduce the number of instance to 1  in Dev and change the ECS launch_type to Fargate-spot.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_Will check after deployment by logging into the ECS console and view the service and instance configuration


### Screenshots of UI changes (if applicable)
![Screenshot 2024-05-22 at 12 53 56](https://github.com/communitiesuk/funding-service-design-assessment/assets/91503321/3c477cc6-b5a3-4b8e-925b-8f78112b5ab8)
![Screenshot 2024-05-22 at 12 11 06](https://github.com/communitiesuk/funding-service-design-assessment/assets/91503321/394c3a89-dfe0-4b98-9729-eb79b11c455d)
