### PR TITLE
FS-4389: Declaration caption should display for Declaration as well as Declarations section

### DIFF
--- a/app/blueprints/assessments/templates/macros/section_element.html
+++ b/app/blueprints/assessments/templates/macros/section_element.html
@@ -4,7 +4,7 @@
         <h2 class="govuk-heading-l govuk-!-margin-top-4">{{ name }}</h2>
     {% endif %}
 
-    {% set caption = "Review against legal and policy requirements." if name == "Declarations" else
+    {% set caption = "Review against legal and policy requirements." if name in ["Declarations", "Declaration"] else
                  ("Use for due diligence checks." if show_caption else "") %}
     <p class="govuk-body govuk-!-text-align-left govuk-!-font-weight-regular govuk-!-margin-bottom-4">
         {{ caption }}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-4389


## Change description
- "Declaration" added in section caption condition

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


## Screenshots of UI changes (if applicable)

### Declaration section added:

<img width="986" alt="Screenshot 2024-06-07 at 16 38 15" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/66220499/532ddfc6-797c-4d81-82e3-101fadbaecab">

### Refurbishment costs and other sections are now accessible:

<img width="1380" alt="Screenshot 2024-06-07 at 16 41 24" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/66220499/e460f337-5aab-4803-b155-c90df453ea41">
