### PR TITLE
BAU: Remove VCAP specific config

### DIFF
--- a/app/blueprints/services/aws.py
+++ b/app/blueprints/services/aws.py
@@ -9,20 +9,11 @@ from flask import url_for
 
 from config import Config
 
-if hasattr(Config, "VCAP_SERVICES"):
-    _S3_CLIENT = client(
-        "s3",
-        aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
-        region_name=Config.AWS_REGION,
-        endpoint_url=getenv("AWS_ENDPOINT_OVERRIDE", None),
-    )
-else:
-    _S3_CLIENT = client(
-        "s3",
-        region_name=Config.AWS_REGION,
-        endpoint_url=getenv("AWS_ENDPOINT_OVERRIDE", None),
-    )
+_S3_CLIENT = client(
+    "s3",
+    region_name=Config.AWS_REGION,
+    endpoint_url=getenv("AWS_ENDPOINT_OVERRIDE", None),
+)
 
 
 def get_file_for_download_from_aws(file_name: str, application_id: str):

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from fsd_utils import CommonConfig
 from fsd_utils import configclass
-from fsd_utils.toggles.vcap_services import VcapServices
 
 
 @configclass
@@ -264,11 +263,7 @@ class DefaultConfig:
     SAMEORIGIN = "SAMEORIGIN"
     ALLOW_FROM = "ALLOW-FROM"
     ONE_YEAR_IN_SECS = 31556926
-
-    if environ.get("VCAP_SERVICES"):
-        FORCE_HTTPS = True
-    else:
-        FORCE_HTTPS = False
+    FORCE_HTTPS = False
 
     TALISMAN_SETTINGS = {
         "feature_policy": FSD_FEATURE_POLICY,
@@ -311,19 +306,6 @@ class DefaultConfig:
         AWS_BUCKET_NAME = environ.get("COPILOT_AWS_BUCKET_NAME")
         AWS_REGION = environ.get("AWS_REGION")
         ASSETS_AUTO_BUILD = False
-    elif "VCAP_SERVICES" in os.environ:
-        VCAP_SERVICES = VcapServices.from_env_json(environ.get("VCAP_SERVICES"))
-
-        if VCAP_SERVICES.does_service_exist(
-            service_key="aws-s3-bucket"  # pragma: allowlist secret
-        ):
-            s3_credentials = VCAP_SERVICES.services.get("aws-s3-bucket")[0].get(
-                "credentials"
-            )
-            AWS_REGION = s3_credentials["aws_region"]
-            AWS_ACCESS_KEY_ID = s3_credentials["aws_access_key_id"]
-            AWS_SECRET_ACCESS_KEY = s3_credentials["aws_secret_access_key"]
-            AWS_BUCKET_NAME = s3_credentials["bucket_name"]
 
     # Redis Feature Toggle Configuration
     REDIS_INSTANCE_URI = getenv("REDIS_INSTANCE_URI", "redis://localhost:6379")

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -7,14 +7,4 @@ from config.envs.default import DefaultConfig
 class DevConfig(DefaultConfig):
     # Redis Feature Toggle Configuration
     REDIS_INSTANCE_NAME = "funding-service-magic-links-dev"
-
-    if not hasattr(DefaultConfig, "VCAP_SERVICES"):
-        REDIS_INSTANCE_URI = DefaultConfig.REDIS_INSTANCE_URI
-    else:
-        REDIS_INSTANCE_URI = DefaultConfig.VCAP_SERVICES.get_service_credentials_value(
-            "redis", REDIS_INSTANCE_NAME, "uri"
-        )
-
-    TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
-
     FSD_LOG_LEVEL = "DEBUG"

--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -5,14 +5,4 @@ from config.envs.default import DefaultConfig
 
 @configclass
 class ProductionConfig(DefaultConfig):
-    # Redis Feature Toggle Configuration
-    REDIS_INSTANCE_NAME = "funding-service-magic-links"
-
-    if not hasattr(DefaultConfig, "VCAP_SERVICES"):
-        REDIS_INSTANCE_URI = DefaultConfig.REDIS_INSTANCE_URI
-    else:
-        REDIS_INSTANCE_URI = DefaultConfig.VCAP_SERVICES.get_service_credentials_value(
-            "redis", REDIS_INSTANCE_NAME, "uri"
-        )
-
-    TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
+    pass

--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -5,17 +5,5 @@ from config.envs.default import DefaultConfig
 
 @configclass
 class TestConfig(DefaultConfig):
-    # Redis Feature Toggle Configuration
-    REDIS_INSTANCE_NAME = "funding-service-magic-links-test"
-
-    if not hasattr(DefaultConfig, "VCAP_SERVICES"):
-        REDIS_INSTANCE_URI = DefaultConfig.REDIS_INSTANCE_URI
-    else:
-        REDIS_INSTANCE_URI = DefaultConfig.VCAP_SERVICES.get_service_credentials_value(
-            "redis", REDIS_INSTANCE_NAME, "uri"
-        )
-
-    TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
-
     # LRU cache settings
     LRU_CACHE_TIME = 300  # in seconds


### PR DESCRIPTION
### Change description
VCAP services is specific to PaaS, so can be safely removed post-PaaS migration.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Tests should pass
Redis connection should still work


### Screenshots of UI changes (if applicable)
