### PR TITLE
Handle application overviews that don't have user associations

### DIFF
--- a/app/blueprints/assessments/helpers.py
+++ b/app/blueprints/assessments/helpers.py
@@ -106,19 +106,20 @@ def set_assigned_info_in_overview(application_overviews, users_for_fund):
     for overview in application_overviews:
         overview["assigned_to_names"] = []
         overview["assigned_to_ids"] = []
-        for user_assocation in overview["user_associations"]:
-            user_id = user_assocation["user_id"]
-            if user_assocation["active"]:
-                overview["assigned_to_ids"].append(user_id)
-                try:
-                    user_details = users_for_fund_dict[user_id]
-                    overview["assigned_to_names"].append(
-                        user_details["full_name"]
-                        if user_details["full_name"]
-                        else user_details["email_address"]
-                    )
-                except KeyError:
-                    users_not_found.append(user_id)
+        if "user_associations" in overview and overview["user_associations"]:
+            for user_assocation in overview["user_associations"]:
+                user_id = user_assocation["user_id"]
+                if user_assocation["active"]:
+                    overview["assigned_to_ids"].append(user_id)
+                    try:
+                        user_details = users_for_fund_dict[user_id]
+                        overview["assigned_to_names"].append(
+                            user_details["full_name"]
+                            if user_details["full_name"]
+                            else user_details["email_address"]
+                        )
+                    except KeyError:
+                        users_not_found.append(user_id)
 
     return application_overviews, users_not_found
 

--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -374,7 +374,9 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
     reporting_to_user_applications = [
         overview
         for overview in post_processed_overviews
-        if any(
+        if "user_associations" in overview
+        and overview["user_associations"]
+        and any(
             assoc["assigner_id"] == g.account_id and assoc["active"]
             for assoc in overview["user_associations"]
         )


### PR DESCRIPTION

### Change description
A quick fix for backwards compatibility where application overviews may not contain user association data.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
