### PR TITLE
Add filter option not assigned to view unassigned applications

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -371,6 +371,11 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
         if g.account_id in application["assigned_to_ids"]
     ]
 
+    fund_user_aliases = [
+        user["full_name"] if user["full_name"] else user["email_address"]
+        for user in users_for_fund
+    ]
+
     reporting_to_user_applications = [
         overview
         for overview in post_processed_overviews
@@ -381,6 +386,23 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
             for assoc in overview["user_associations"]
         )
     ]
+
+    # Filter by assigned to here as it's not a searchable parameter on assessment store
+    if "assigned_to" in search_params and post_processed_overviews:
+        if search_params["assigned_to"] == "ALL":
+            pass
+        elif search_params["assigned_to"] == "Not assigned":
+            post_processed_overviews = [
+                overview
+                for overview in post_processed_overviews
+                if len(overview["assigned_to_names"]) == 0
+            ]
+        else:
+            post_processed_overviews = [
+                overview
+                for overview in post_processed_overviews
+                if search_params["assigned_to"] in overview["assigned_to_names"]
+            ]
 
     return render_template(
         "fund_dashboard.html",
@@ -409,7 +431,7 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
         local_authorities=all_application_locations._local_authorities,
         migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
         dpi_filters=dpi_filters,
-        users=["All"],  # TODO: Add users api call
+        users=["All", "Not assigned"] + fund_user_aliases,
     )
 
 

--- a/app/blueprints/assessments/templates/fund_dashboard.html
+++ b/app/blueprints/assessments/templates/fund_dashboard.html
@@ -127,7 +127,7 @@
         tag_option_groups,
         tags,
         tagging_purpose_config,
-        users
+        [user['full_name']]
         ) }}
         {% endset -%}
 

--- a/app/blueprints/assessments/templates/fund_dashboard.html
+++ b/app/blueprints/assessments/templates/fund_dashboard.html
@@ -103,7 +103,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        show_clear_filters,
+        {'show_clear_filters' : show_clear_filters, 'tab_id' : "all-applications"},
         sort_column,
         sort_order,
         tag_option_groups,
@@ -121,13 +121,13 @@
         query_params,
         asset_types,
         assessment_statuses,
-        show_clear_filters,
+        {'show_clear_filters' : show_clear_filters, 'tab_id' : "assigned-to-you"},
         sort_column,
         sort_order,
         tag_option_groups,
         tags,
         tagging_purpose_config,
-        [user['full_name']]
+        []
         ) }}
         {% endset -%}
 
@@ -139,7 +139,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        show_clear_filters,
+        {'show_clear_filters' : show_clear_filters, 'tab_id' : "reporting-to-you"},
         sort_column,
         sort_order,
         tag_option_groups,

--- a/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
+++ b/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
@@ -5,7 +5,7 @@
 {% from "macros/tags_table.html" import tags_table %}
 
 {% macro render(application_overviews, round_details, query_params, asset_types,
-assessment_statuses, show_clear_filters,
+assessment_statuses, clear_search_config,
 sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users) -%}
 <nav class="search-bar-flex-container">
   <form method="get" class="govuk-!-width-full">
@@ -14,7 +14,7 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
     'Search reference or project name',
     assessment_statuses,
     round_details,
-    show_clear_filters,
+    clear_search_config,
     tag_option_groups,
     users
     ) }}

--- a/app/blueprints/assessments/templates/macros/filter_options_all.html
+++ b/app/blueprints/assessments/templates/macros/filter_options_all.html
@@ -1,4 +1,4 @@
-{% macro filter_options(query_params, search_label, assessment_statuses, round_details, show_clear_filters, tag_option_groups, users) %}
+{% macro filter_options(query_params, search_label, assessment_statuses, round_details, clear_search_config, tag_option_groups, users) %}
 
 <fieldset class="govuk-fieldset">
     <div class="govuk-grid-row">
@@ -24,16 +24,18 @@
                 </select>
             </div>
             {% endif %}
+            {% if users|length > 0 %}
             <div class="govuk-form-group govuk-!-display-inline-block govuk-!-margin-bottom-0 govuk-!-margin-right-2">
                 <label class="govuk-label" for="filter_assigned_to">
                     Filter by assigned to
                 </label>
-                <select class="govuk-select govuk-!-width-one-quarter" id="filter_assigned_to" name="assigned_to" {% if users|length < 2 %} disabled {% endif %}>{{ user }}>
+                <select class="govuk-select govuk-!-width-one-quarter" id="filter_assigned_to" name="assigned_to">{{ user }}>
                     {% for user in users %}
                         <option value='{{ user }}' {% if query_params.assigned_to==user %} selected="" {% endif %}>{{ user }}</option>
                     {% endfor %}
                 </select>
             </div>
+            {% endif %}
             <div class="govuk-form-group govuk-!-display-inline-block govuk-!-margin-bottom-0 govuk-!-margin-right-2">
                 <label class="govuk-label" for="filter_by_tag">
                     Filter by tag
@@ -57,12 +59,15 @@
                     type="submit">
                     Search
                 </button>
-                {% if show_clear_filters %}
+                {% if clear_search_config["show_clear_filters"] %}
                 <p>
                     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assessment_bp.fund_dashboard',
-                                      fund_short_name=round_details.fund_short_name,
-                                      round_short_name=round_details.round_short_name,
-                                      clear_filters=true) }}" aria-label="Clear Filters">Clear search</a>
+                    fund_short_name=round_details.fund_short_name,
+                    round_short_name=round_details.round_short_name,
+                    clear_filters=true,
+                    _anchor=clear_search_config["tab_id"]) }}" aria-label="Clear Filters">
+                    Clear search
+                    </a>
                 </p>
                 {% endif %}
             </div>

--- a/app/blueprints/assessments/templates/macros/filter_options_all.html
+++ b/app/blueprints/assessments/templates/macros/filter_options_all.html
@@ -28,7 +28,7 @@
                 <label class="govuk-label" for="filter_assigned_to">
                     Filter by assigned to
                 </label>
-                <select class="govuk-select govuk-!-width-one-quarter" id="filter_assigned_to" name="assigned_to">
+                <select class="govuk-select govuk-!-width-one-quarter" id="filter_assigned_to" name="assigned_to" {% if users|length < 2 %} disabled {% endif %}>{{ user }}>
                     {% for user in users %}
                         <option value='{{ user }}' {% if query_params.assigned_to==user %} selected="" {% endif %}>{{ user }}</option>
                     {% endfor %}

--- a/app/blueprints/assessments/templates/macros/filter_options_all.html
+++ b/app/blueprints/assessments/templates/macros/filter_options_all.html
@@ -61,6 +61,7 @@
                 </button>
                 {% if clear_search_config["show_clear_filters"] %}
                 <p>
+                    {# djlint:off #}
                     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assessment_bp.fund_dashboard',
                     fund_short_name=round_details.fund_short_name,
                     round_short_name=round_details.round_short_name,
@@ -68,6 +69,7 @@
                     _anchor=clear_search_config["tab_id"]) }}" aria-label="Clear Filters">
                     Clear search
                     </a>
+                    {# djlint:on #}
                 </p>
                 {% endif %}
             </div>

--- a/config/display_value_mappings.py
+++ b/config/display_value_mappings.py
@@ -51,6 +51,7 @@ search_params_default = {
     "asset_type": ALL_VALUE,
     "status": ALL_VALUE,
     "filter_by_tag": ALL_VALUE,
+    "assigned_to": ALL_VALUE,
 }
 search_params_cof = {
     "search_term": "",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,6 +405,7 @@ def mock_get_application_overviews(request, mocker):
             "search_term": "",
             "search_in": "project_name,short_id",
             "asset_type": "ALL",
+            "assigned_to": "ALL",
             "status": "ALL",
             "filter_by_tag": "ALL",
         }

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -53,6 +53,7 @@ def test_route_landing_maintenance_mode_enabled(
             "search_term": "",
             "search_in": "project_name,short_id",
             "asset_type": "ALL",
+            "assigned_to": "ALL",
             "status": "ALL",
             "filter_by_tag": "ALL",
         },


### PR DESCRIPTION
### Change description
Drop down filter should include 'Not assigned' option to view applications that have not been assigned yet. 

This also includes a bug fix: when using the 'clear search' link, the view now remains on the current tab rather than switching to 'all applications'.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Test the UI to ensure filtering works.


### Screenshots of UI changes (if applicable)
![Screenshot 2024-07-18 at 16 40 34](https://github.com/user-attachments/assets/43265673-5e94-441c-b2ed-f2540b243e01)

