### PR TITLE
FS-3987 assign user assessment

### DIFF
--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -1,0 +1,75 @@
+from flask import request
+from flask_wtf import FlaskForm
+
+
+class AssessmentAssignmentForm(FlaskForm):
+    def validate(self, extra_validators=None):
+        if super().validate(extra_validators):
+            if request.referrer != request.url:
+                # From a redirect, not a form post
+                return False
+
+            if not request.form.getlist("selected_assessments"):
+                self.form_errors.append("At least one assessment should be selected")
+                return False
+            else:
+                return True
+
+        return False
+
+
+class AssessorTypeForm(FlaskForm):
+    def validate(self, extra_validators=None):
+        if super().validate(extra_validators):
+            if request.referrer != request.url:
+                # From a redirect, not a form post
+                return False
+
+            if not request.form.getlist("assessor_role"):
+                self.form_errors.append("An assessor type should be selected")
+                return False
+            else:
+                return True
+
+        return False
+
+
+class AssessorChoiceForm(FlaskForm):
+    def validate(self, extra_validators=None):
+        if super().validate(extra_validators):
+            if request.referrer != request.url:
+                # From a redirect, not a form post
+                return False
+
+            if not request.form.getlist("selected_users"):
+                self.form_errors.append("At least one assessor should be selected")
+                return False
+            else:
+                return True
+
+        return False
+
+
+class AssignmentOverviewForm(FlaskForm):
+    def validate(self, extra_validators=None):
+        if super().validate(extra_validators):
+            if request.referrer != request.url:
+                # From a redirect, not a form post
+                return False
+
+            passed_validation = True
+            if not request.form.getlist("selected_users"):
+                self.form_errors.append("At least one assessor should be selected")
+                passed_validation = False
+
+            if not request.form.getlist("assessor_role"):
+                self.form_errors.append("An assessor type should be selected")
+                passed_validation = False
+
+            if not request.form.getlist("selected_assessments"):
+                self.form_errors.append("At least one assessment should be selected")
+                passed_validation = False
+
+            return passed_validation
+
+        return False

--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -84,6 +84,7 @@ from app.blueprints.services.data_services import get_applicant_export
 from app.blueprints.services.data_services import (
     get_applicant_feedback_and_survey_report,
 )
+from app.blueprints.services.data_services import get_application_assignments
 from app.blueprints.services.data_services import get_application_json
 from app.blueprints.services.data_services import get_application_overviews
 from app.blueprints.services.data_services import (
@@ -93,7 +94,6 @@ from app.blueprints.services.data_services import get_assessment_progress
 from app.blueprints.services.data_services import get_associated_tags_for_application
 from app.blueprints.services.data_services import get_bulk_accounts_dict
 from app.blueprints.services.data_services import get_comments
-from app.blueprints.services.data_services import get_data
 from app.blueprints.services.data_services import get_flags
 from app.blueprints.services.data_services import get_fund
 from app.blueprints.services.data_services import get_funds
@@ -695,10 +695,8 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
         # Check for existing assignments between user and application
         future_to_app = {
             thread_executor.submit(
-                get_data,
-                Config.ASSESSMENT_ASSIGNED_USERS_ENDPOINT.format(
-                    application_id=application_id
-                ),
+                get_application_assignments,
+                application_id,
             ): application_id
             for application_id in selected_assessments
         }

--- a/app/blueprints/assessments/templates/assessor_type.html
+++ b/app/blueprints/assessments/templates/assessor_type.html
@@ -27,34 +27,43 @@
         <header class="govuk-body">
             <h1 class="govuk-heading-l">Assign to lead assessor or general assessor</h1>
         </header>
-        <p class="govuk-body">Select the type of role you would like to assign.</p>
-        <form method="post" action="{{ url_for('assessment_bp.assessor_type_list',
-                    fund_short_name=round_details.fund_short_name,
-                    round_short_name=round_details.round_short_name) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            {% for assessment in selected_assessments %}
-            <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+        <div class="govuk-form-group {% if form.form_errors %} govuk-form-group--error {% endif %}">
+            {% if form.form_errors %}
+            <p class="govuk-error-message">
+            {% for error in form.form_errors %}
+                <span class="govuk-visually-hidden">Error:</span> {{ error }}
             {% endfor %}
-            <div class="govuk-radios">
-                <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="lead_assessor" name="assessor_role" type="radio" value="lead_assessor">
-                    <label class="govuk-label govuk-radios__label" for="lead_assessor">
-                        Lead assessor
-                    </label>
-                    <span class="govuk-hint">
-                        A lead assessor is the person who is responsible for the entire assessment
-                    </span>
+            </p>
+            {% endif %}
+            <p class="govuk-body">Select the type of role you would like to assign.</p>
+            <form method="post" action="{{ url_for('assessment_bp.assessor_type',
+                        fund_short_name=round_details.fund_short_name,
+                        round_short_name=round_details.round_short_name) }}">
+                {{ form.csrf_token }}
+                {% for assessment in selected_assessments %}
+                <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+                {% endfor %}
+                <div class="govuk-radios">
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="lead_assessor" name="assessor_role" type="radio" value="lead_assessor" {% if selected_assessor_role == "lead_assessor" %}checked{% endif %}>
+                        <label class="govuk-label govuk-radios__label" for="lead_assessor">
+                            Lead assessor
+                        </label>
+                        <span class="govuk-hint">
+                            A lead assessor is the person who is responsible for the entire assessment
+                        </span>
+                    </div>
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="general_assessor" name="assessor_role" type="radio" value="general_assessor" {% if selected_assessor_role == "general_assessor" %}checked{% endif %}>
+                        <label class="govuk-label govuk-radios__label" for="general_assessor">
+                            General assessor
+                        </label>
+                        <span class="govuk-hint">
+                            A general assessor is a person who is responsible for completing part of an assessment
+                        </span>
+                    </div>
                 </div>
-                <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="general_assessor" name="assessor_role" type="radio" value="general_assessor">
-                    <label class="govuk-label govuk-radios__label" for="general_assessor">
-                        General assessor
-                    </label>
-                    <span class="govuk-hint">
-                        A general assessor is a person who is responsible for completing part of an assessment
-                    </span>
-                </div>
-            </div>
+        </div>
             <div class="govuk-!-margin-top-4">
                 <button type="submit" class="govuk-button">Continue</button>
             </div>

--- a/app/blueprints/assessments/templates/assessor_type.html
+++ b/app/blueprints/assessments/templates/assessor_type.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
+{% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% from "macros/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}Team dashboard{% endset %}
+
+{% block header %}
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
+{% endblock header %}
+
+{% block content %}
+{# CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
+
+
+<div class="govuk-grid-row">
+    {% if migration_banner_enabled %}
+    {{ migration_banner() }}
+    {% endif %}
+    <section id="assign-assessor-role" class="govuk-width-container govuk-grid-column-full">
+        <header class="govuk-body">
+            <h1 class="govuk-heading-l">Assign to lead assessor or general assessor</h1>
+        </header>
+        <p class="govuk-body">Select the type of role you would like to assign.</p>
+        <form method="post" action="{{ url_for('assessment_bp.assessor_type_list',
+                    fund_short_name=round_details.fund_short_name,
+                    round_short_name=round_details.round_short_name) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% for assessment in selected_assessments %}
+            <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+            {% endfor %}
+            <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="lead_assessor" name="assessor_role" type="radio" value="lead_assessor">
+                    <label class="govuk-label govuk-radios__label" for="lead_assessor">
+                        Lead assessor
+                    </label>
+                    <span class="govuk-hint">
+                        A lead assessor is the person who is responsible for the entire assessment
+                    </span>
+                </div>
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="general_assessor" name="assessor_role" type="radio" value="general_assessor">
+                    <label class="govuk-label govuk-radios__label" for="general_assessor">
+                        General assessor
+                    </label>
+                    <span class="govuk-hint">
+                        A general assessor is a person who is responsible for completing part of an assessment
+                    </span>
+                </div>
+            </div>
+            <div class="govuk-!-margin-top-4">
+                <button type="submit" class="govuk-button">Continue</button>
+            </div>
+        </form>
+    </section>
+</div>
+{% endblock content %}

--- a/app/blueprints/assessments/templates/assign_assessments.html
+++ b/app/blueprints/assessments/templates/assign_assessments.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
+{% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% from "macros/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}Team dashboard{% endset %}
+
+{% block header %}
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
+{% endblock header %}
+
+{% block content %}
+{# CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
+
+
+<div class="govuk-grid-row">
+    {% if migration_banner_enabled %}
+    {{ migration_banner() }}
+    {% endif %}
+    {% macro ApplicationsOverviewHtmlBase(heading_text) %}
+    <header class="govuk-body ">
+        <h1 class="govuk-heading-l">Assign assessments</h1>
+    </header>
+    <p class="govuk-body">Select the assessments you would like to assign to others</p>
+    {% endmacro -%}
+    <section id="application-overview" class="govuk-width-container govuk-grid-column-full">
+        {{ ApplicationsOverviewHtmlBase("All applications") }}
+        {{ application_overviews_table.render(
+        application_overviews,
+        round_details,
+        query_params,
+        asset_types,
+        assessment_statuses,
+        {"show_clear_filters" : show_clear_filters, "assessments_selectable" : True},
+        sort_column,
+        sort_order,
+        tag_option_groups,
+        tags,
+        tagging_purpose_config,
+        users
+        ) }}
+    </section>
+</div>
+{% endblock content %}

--- a/app/blueprints/assessments/templates/assign_assessments.html
+++ b/app/blueprints/assessments/templates/assign_assessments.html
@@ -37,7 +37,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        {"show_clear_filters" : show_clear_filters, "assessments_selectable" : True},
+        {"show_clear_filters" : show_clear_filters, "assessment_form" : form, "selected_assessments" : selected_assessments},
         sort_column,
         sort_order,
         tag_option_groups,

--- a/app/blueprints/assessments/templates/assignment_overview.html
+++ b/app/blueprints/assessments/templates/assignment_overview.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
+{% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% from "macros/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}Team dashboard{% endset %}
+
+{% block header %}
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
+{% endblock header %}
+
+{% block content %}
+{# CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
+
+
+<div class="govuk-grid-row">
+    {% if migration_banner_enabled %}
+    {{ migration_banner() }}
+    {% endif %}
+    <section id="select-assessors" class="govuk-width-container govuk-grid-column-full">
+        <header class="govuk-body">
+            <h1 class="govuk-heading-l">Assign assessments to {{ "lead" if assessor_role == "lead_assessor" else "general" }}  assessor</h1>
+        </header>
+        <div class="govuk-form-group {% if form.form_errors %} govuk-form-group--error {% endif %}">
+            {% if form.form_errors %}
+            <p class="govuk-error-message">
+            {% for error in form.form_errors %}
+                <span class="govuk-visually-hidden">Error:</span> {{ error }}
+            {% endfor %}
+            </p>
+            {% else %}
+            <p class="govuk-body">
+                You are about to assign <strong>{{ selected_user_names|join(', ') }} </strong> to {{ selected_assessments|length }} assessment{% if selected_assessments |length > 1 %}s{% endif %} as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor.
+                {# You are about to remove <strong>{{ remove_user }}</strong> from <strong>{{ assessment_count }}</strong> assessment{% if assessment_count > 1 %}s{% endif %} and assign <strong>{{ assign_user }}</strong> to the same assessment{% if assessment_count > 1 %}s{% endif %} as a general assessor. #}
+            </p>
+            {% endif %}
+            <form method="post" action="{{ url_for('assessment_bp.assignment_overview',
+            fund_short_name=round_details.fund_short_name,
+            round_short_name=round_details.round_short_name) }}">
+            {{ form.csrf_token }}
+            {% if form.form_errors %}
+            <ul class="errors">
+            {% for error in form.form_errors %}
+                <p class="govuk-error-message">
+                    <li>{{ error }}</li>
+                </p>
+            {% endfor %}
+            </ul>
+            {% endif %}
+            {% for assessment in selected_assessments %}
+            <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+            {% endfor %}
+            <input type="hidden" name="assessor_role" value="{{ assessor_role }}">
+            {% for user in selected_users %}
+            <input type="hidden" name="selected_users" value="{{ user }}">
+            {% endfor %}
+            <p class="govuk-body">
+                <button type="submit" class="govuk-link btn-link" name="change_roles" value="change_roles">Change roles</button> or
+                <button type="submit" class="govuk-link btn-link" name="change_users" value="change_users">Change users</button>
+            </p>
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Reference</th>
+                        <th scope="col" class="govuk-table__header">Project name</th>
+                        <th scope="col" class="govuk-table__header">Funding requested</th>
+                        <th scope="col" class="govuk-table__header">Location</th>
+                        <th scope="col" class="govuk-table__header">Status</th>
+                        <th scope="col" class="govuk-table__header">Assigned to</th>
+                        <th scope="col" class="govuk-table__header">Last action</th>
+                        <th scope="col" class="govuk-table__header">Time since last action</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for overview in assessments %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">{{ overview.short_id[-6:] }}</td>
+                        <td class="govuk-table__cell"><a class="govuk-link" data-qa="project_name"
+                            href="{{ url_for('assessment_bp.application',application_id=overview.application_id) }}">{{
+                            overview.project_name }}</a></td>
+                        <td class="govuk-table__cell">£{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
+                        <td class="govuk-table__cell">{{ overview.location_json_blob.get('country') or "Not found" }}</td>
+                        <td class="govuk-table__cell">{{ "TODO" }}</td>
+                        <td class="govuk-table__cell">
+                            {% if overview.assigned_to_names %}
+                            {% for name in overview.assigned_to_names %}
+                            <span class="assigned-to">{{ name }}</span><br>
+                            {% endfor %}
+                        {% else %}
+                            -
+                        {% endif %}</td>
+                        <td class="govuk-table__cell">-</td>
+                        <td class="govuk-table__cell">-</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <button type="submit" class="govuk-link btn-link" name="change_assessments" value="change_assessments">Add/remove assessments</button>
+    </div>
+            {#
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="message">Message to assessors assigned (optional)</label>
+                <textarea class="govuk-textarea" id="message" name="message" rows="3">{{ message }}</textarea>
+            </div>
+            #}
+            <button class="govuk-button" type="submit">Assign assessments</button>
+        </form>
+    </section>
+</div>
+{% endblock content %}

--- a/app/blueprints/assessments/templates/assignment_overview.html
+++ b/app/blueprints/assessments/templates/assignment_overview.html
@@ -36,7 +36,7 @@
             </p>
             {% else %}
             <p class="govuk-body">
-                You are about to assign <strong>{{ selected_user_names|join(', ') }} </strong> to {{ selected_assessments|length }} assessment{% if selected_assessments |length > 1 %}s{% endif %} as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor.
+                You are about to assign <strong>{{ selected_user_names|join(', ') }}</strong> to {{ selected_assessments|length }} assessment{% if selected_assessments |length > 1 %}s{% endif %} as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor.
                 {# You are about to remove <strong>{{ remove_user }}</strong> from <strong>{{ assessment_count }}</strong> assessment{% if assessment_count > 1 %}s{% endif %} and assign <strong>{{ assign_user }}</strong> to the same assessment{% if assessment_count > 1 %}s{% endif %} as a general assessor. #}
             </p>
             {% endif %}

--- a/app/blueprints/assessments/templates/fund_dashboard.html
+++ b/app/blueprints/assessments/templates/fund_dashboard.html
@@ -1,71 +1,16 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
 {% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
 {% from "macros/banner_summary.html" import banner_summary %}
-{% from "macros/logout_partial.html" import logout_partial %}
 {% from "macros/migration_banner.html" import migration_banner %}
 
 {% set pageHeading %}Team dashboard{% endset %}
 
 {% block header %}
-<header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
-            <p
-                class="govuk-!-text-align-left govuk-!-margin-left-3 flex-parent-element flexed-element-margins-collapse">
-                {{ govukBackLink({'href': url_for("assessment_bp.landing"), 'html': 'Back to <b>assessment landing</b>',
-                'attributes': {'data-qa': 'back-to-assessment-overview-link'} }) }}
-            </p>
-            {{ logout_partial(sso_logout_url) }}
-        </div>
-    </nav>
-
-    <div class="fsd-banner-background">
-        <div class="govuk-width-container">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <div class="govuk-grid-column-two-thirds">
-                        <h1 class="govuk-heading-xl fsd-banner-content">{{ pageHeading }}</h1>
-                        {% if g.access_controller.is_lead_assessor %}
-                        <div class="govuk-body fsd-banner-content lead-dashboard-stats">
-                            {% if round_details["is_expression_of_interest"] %}
-                            <div class="lead-dashboard-stat">
-                                <p id="lead-dashboard-stat-assessments-qa-completed">{{ stats.qa_completed }}</p>
-                                <p class="lead-dashboard-stat-assessments-completed">QA complete</p>
-                            </div>
-                            {% endif %}
-                            <div class="lead-dashboard-stat">
-                                <p id="lead-dashboard-stat-assessments-total">{{ stats.total }}</p>
-                                <p>Assessments</p>
-                            </div>
-                            {% for team in team_flag_stats %}
-                            {% if team.raised > 0 and team.team_name %}
-                            <div class="lead-dashboard-stat">
-                                <p id="lead-dashboard-stat-assessments-total">{{ team.raised }}</p>
-                                <p>Total flagged for {{ team.team_name }}</p>
-                            </div>
-                            {% endif %}
-                            {% endfor %}
-                        </div>
-                        {% endif %}
-                        <h2 class="govuk-heading-l fsd-banner-content"> {% if is_active_status %}All active
-                            assessments{% else %}All closed assessments{% endif %}</h2>
-                        <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding"><strong>Fund: </strong>{{
-                            round_details["fund_name"] }}</p>
-                        {% if not round_details["is_expression_of_interest"] %}
-                        <p class="govuk-body-l fsd-banner-content"><strong>Round: </strong>{{
-                            round_details["round_title"] }}</p>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</header>
-
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
 {% endblock header %}
 
 {% block content %}
@@ -78,24 +23,22 @@
     {% endif %}
     {% macro ApplicationsOverviewHtmlBase(heading_text) %}
     <header class="govuk-body ">
-                <!--
-        TODO: Add later
             <section class="govuk-phase-banner govuk-grid-row">
                 <span id="empty-positioning-child" class="govuk-grid-column-two-thirds empty-positioning-child">&nbsp;</span>
                 <span class="govuk-grid-column-one-third">
-                    <a href="." class="govuk-link govuk-!-margin-right-4">
-                        Edit table columns</a>
-                    <a href="." class="govuk-link">
+                    <a href="{{ url_for('assessment_bp.assign_assessments',
+                      fund_short_name=round_details.fund_short_name,
+                      round_short_name=round_details.round_short_name)}}" class="govuk-link">
                         Assign assessments
                     </a>
                 </span>
             </section>
-        -->
         <h1 class="govuk-heading-l">{{ heading_text }}</h1>
     </header>
     {% endmacro -%}
     <section id="application-overview" class="govuk-width-container govuk-grid-column-full">
         {% set allApplicationsOverviewHtml %}
+        {% set all_apps_display_config = display_config | add_to_dict({'tab_id': 'all-applications'}) %}
         {{ ApplicationsOverviewHtmlBase("All applications") }}
         {{ application_overviews_table.render(
         application_overviews,
@@ -103,7 +46,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        {'show_clear_filters' : show_clear_filters, 'tab_id' : "all-applications"},
+        all_apps_display_config,
         sort_column,
         sort_order,
         tag_option_groups,
@@ -114,6 +57,7 @@
         {% endset -%}
 
         {% set assignedApplicationsHtml %}
+        {% set assigned_display_config = display_config | add_to_dict({'tab_id': 'assigned-to-you'}) %}
         {{ ApplicationsOverviewHtmlBase("Assigned to you") }}
         {{ application_overviews_table.render(
         assigned_applications,
@@ -121,7 +65,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        {'show_clear_filters' : show_clear_filters, 'tab_id' : "assigned-to-you"},
+        assigned_display_config,
         sort_column,
         sort_order,
         tag_option_groups,
@@ -132,6 +76,7 @@
         {% endset -%}
 
         {% set reportingToYouApplicationsOverviewHtml %}
+        {% set reporting_display_config = display_config | add_to_dict({'tab_id': 'reporting-to-you'}) %}
         {{ ApplicationsOverviewHtmlBase("Reporting to you") }}
         {{ application_overviews_table.render(
         reporting_to_user_applications,
@@ -139,7 +84,7 @@
         query_params,
         asset_types,
         assessment_statuses,
-        {'show_clear_filters' : show_clear_filters, 'tab_id' : "reporting-to-you"},
+        reporting_display_config,
         sort_column,
         sort_order,
         tag_option_groups,
@@ -151,12 +96,12 @@
 
         {{ govukTabs({
         "items": [
-        {
-        "label": "All applications",
-        "id": "all-applications",
-        "panel": {
-        "html": allApplicationsOverviewHtml
-        }
+            {
+            "label": "All applications",
+            "id": "all-applications",
+            "panel": {
+            "html": allApplicationsOverviewHtml
+            }
         },
         {
             "label": "Assigned to you (" ~ assigned_applications | length ~ ")",

--- a/app/blueprints/assessments/templates/fund_dashboard.html
+++ b/app/blueprints/assessments/templates/fund_dashboard.html
@@ -23,6 +23,7 @@
     {% endif %}
     {% macro ApplicationsOverviewHtmlBase(heading_text) %}
     <header class="govuk-body ">
+            {% if user.highest_role_map[round_details.fund_short_name] == 'LEAD_ASSESSOR' and toggle_dict.get("ASSESSMENT_ASSIGNMENT") %}
             <section class="govuk-phase-banner govuk-grid-row">
                 <span id="empty-positioning-child" class="govuk-grid-column-two-thirds empty-positioning-child">&nbsp;</span>
                 <span class="govuk-grid-column-one-third">
@@ -33,6 +34,7 @@
                     </a>
                 </span>
             </section>
+            {% endif %}
         <h1 class="govuk-heading-l">{{ heading_text }}</h1>
     </header>
     {% endmacro -%}

--- a/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
+++ b/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
@@ -33,19 +33,26 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
   </ul>
 </div>
 {% else %}
-  {% if display_config["assessments_selectable"] %}
-  <form method="post" action="{{ url_for('assessment_bp.assessor_type',
+  {% if display_config["assessment_form"] %}
+  <form method="post" action="{{ url_for('assessment_bp.assign_assessments',
                       fund_short_name=round_details.fund_short_name,
                       round_short_name=round_details.round_short_name) }}">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    {{ display_config["assessment_form"].csrf_token }}
   {% endif %}
   <table class="govuk-table govuk-!-margin-top-4" id="application_overviews_table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        {% if display_config["assessments_selectable"] %}
+        {% if display_config["assessment_form"] %}
         <th scope="col" class="govuk-table__header">
           <input type="checkbox" id="select_all_for_assignment" />
         </th>
+          {% if display_config["assessment_form"].form_errors %}
+            <ul class="errors">
+            {% for error in display_config["assessment_form"].form_errors %}
+                <li>{{ error }}</li>
+            {% endfor %}
+            </ul>
+          {% endif %}
         {% endif %}
         <th scope="col" class="govuk-table__header">
           Reference
@@ -68,9 +75,9 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
   <tbody class="govuk-table__body">
     {% for overview in application_overviews %}
     <tr class="govuk-table__row">
-      {% if display_config["assessments_selectable"] %}
+      {% if display_config["assessment_form"] %}
       <td class="govuk-table__cell">
-        <input type="checkbox" name="selected_assessments" value="{{ overview.application_id }}" />
+        <input type="checkbox" name="selected_assessments" value="{{ overview.application_id }}" {% if overview.application_id in display_config["selected_assessments"] %}checked{% endif %} />
       </td>
       {% endif %}
       <td class="govuk-table__cell">{{ overview.short_id[-6:] }}</td>
@@ -98,7 +105,7 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
     {% endfor %}
   </tbody>
 </table>
-  {% if display_config["assessments_selectable"] %}
+  {% if display_config["assessment_form"] %}
   <div class="govuk-!-margin-top-4">
     <button type="submit" class="govuk-button">Continue</button>
   </div>

--- a/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
+++ b/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
@@ -5,7 +5,7 @@
 {% from "macros/tags_table.html" import tags_table %}
 
 {% macro render(application_overviews, round_details, query_params, asset_types,
-assessment_statuses, clear_search_config,
+assessment_statuses, display_config,
 sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users) -%}
 <nav class="search-bar-flex-container">
   <form method="get" class="govuk-!-width-full">
@@ -14,7 +14,7 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
     'Search reference or project name',
     assessment_statuses,
     round_details,
-    clear_search_config,
+    display_config,
     tag_option_groups,
     users
     ) }}
@@ -33,31 +33,46 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
   </ul>
 </div>
 {% else %}
-<table class="govuk-table govuk-!-margin-top-4" id="application_overviews_table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">
-        Reference
-      </th>
-      {{ sortable_table_header('project_name', 'Project name', sort_order, sort_column, round_details, query_params) }}
-      {{ sortable_table_header('funding_requested', 'Funding requested', sort_order, sort_column, round_details,
-      query_params) }}
-      {{ sortable_table_header('asset_type', 'Asset type', sort_order, sort_column, round_details, query_params) }}
-      {{ sortable_table_header('location', 'Location', sort_order, sort_column, round_details, query_params) }}
-      {{ sortable_table_header('tags', 'Tags', sort_order, sort_column, round_details, query_params) }}
-      {% if g.access_controller.has_any_assessor_role %}
-      {{ sortable_table_header('status', 'Status', sort_order, sort_column, round_details, query_params) }}
-      {% endif %}
-      {{ sortable_table_header('assigned_to', 'Assigned to', sort_order, sort_column, round_details, query_params) }}
-      {{ sortable_table_header('last_action', 'Last action', sort_order, sort_column, round_details, query_params) }}
-      {{ sortable_table_header('time_since_last_action', 'Time since last action', sort_order, sort_column,
-      round_details, query_params) }}
-    </tr>
-  </thead>
+  {% if display_config["assessments_selectable"] %}
+  <form method="post" action="{{ url_for('assessment_bp.assessor_type',
+                      fund_short_name=round_details.fund_short_name,
+                      round_short_name=round_details.round_short_name) }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% endif %}
+  <table class="govuk-table govuk-!-margin-top-4" id="application_overviews_table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        {% if display_config["assessments_selectable"] %}
+        <th scope="col" class="govuk-table__header">
+          <input type="checkbox" id="select_all_for_assignment" />
+        </th>
+        {% endif %}
+        <th scope="col" class="govuk-table__header">
+          Reference
+        </th>
+        {{ sortable_table_header('project_name', 'Project name', sort_order, sort_column, round_details, query_params) }}
+        {{ sortable_table_header('funding_requested', 'Funding requested', sort_order, sort_column, round_details,
+        query_params) }}
+        {{ sortable_table_header('asset_type', 'Asset type', sort_order, sort_column, round_details, query_params) }}
+        {{ sortable_table_header('location', 'Location', sort_order, sort_column, round_details, query_params) }}
+        {{ sortable_table_header('tags', 'Tags', sort_order, sort_column, round_details, query_params) }}
+        {% if g.access_controller.has_any_assessor_role %}
+        {{ sortable_table_header('status', 'Status', sort_order, sort_column, round_details, query_params) }}
+        {% endif %}
+        {{ sortable_table_header('assigned_to', 'Assigned to', sort_order, sort_column, round_details, query_params) }}
+        {{ sortable_table_header('last_action', 'Last action', sort_order, sort_column, round_details, query_params) }}
+        {{ sortable_table_header('time_since_last_action', 'Time since last action', sort_order, sort_column,
+        round_details, query_params) }}
+      </tr>
+    </thead>
   <tbody class="govuk-table__body">
     {% for overview in application_overviews %}
     <tr class="govuk-table__row">
-
+      {% if display_config["assessments_selectable"] %}
+      <td class="govuk-table__cell">
+        <input type="checkbox" name="selected_assessments" value="{{ overview.application_id }}" />
+      </td>
+      {% endif %}
       <td class="govuk-table__cell">{{ overview.short_id[-6:] }}</td>
       <td class="govuk-table__cell"><a class="govuk-link" data-qa="project_name"
           href="{{ url_for('assessment_bp.application',application_id=overview.application_id) }}">{{
@@ -69,7 +84,6 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
       {% if g.access_controller.has_any_assessor_role %}
       {{ application_status_column(overview.application_status, overview.get("progress", ""), assessment_statuses) }}
       {% endif %}
-      <!-- TODO: requires 'assigned to' API -->
       <td class="govuk-table__cell">
         {% if overview.assigned_to_names %}
         {% for name in overview.assigned_to_names %}
@@ -84,5 +98,11 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
     {% endfor %}
   </tbody>
 </table>
+  {% if display_config["assessments_selectable"] %}
+  <div class="govuk-!-margin-top-4">
+    <button type="submit" class="govuk-button">Continue</button>
+  </div>
+  </form>
+  {% endif %}
 {% endif %}
 {%- endmacro %}

--- a/app/blueprints/assessments/templates/macros/filter_options_all.html
+++ b/app/blueprints/assessments/templates/macros/filter_options_all.html
@@ -1,4 +1,4 @@
-{% macro filter_options(query_params, search_label, assessment_statuses, round_details, clear_search_config, tag_option_groups, users) %}
+{% macro filter_options(query_params, search_label, assessment_statuses, round_details, display_config, tag_option_groups, users) %}
 
 <fieldset class="govuk-fieldset">
     <div class="govuk-grid-row">
@@ -59,19 +59,17 @@
                     type="submit">
                     Search
                 </button>
-                {% if clear_search_config["show_clear_filters"] %}
+                {% if display_config["show_clear_filters"] %}
                 <p>
                     {# djlint:off #}
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('assessment_bp.fund_dashboard',
-                    fund_short_name=round_details.fund_short_name,
-                    round_short_name=round_details.round_short_name,
-                    clear_filters=true,
-                    _anchor=clear_search_config["tab_id"]) }}" aria-label="Clear Filters">
+                    {% set updated_url = request.url.replace(request.query_string.decode(), '') %}
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ updated_url }}?fund_short_name={{ round_details.fund_short_name }}&round_short_name={{ round_details.round_short_name }}&clear_filters=true{{ "#" + display_config["tab_id"] if "tab_id" in display_config else ""}}" aria-label="Clear Filters">
                     Clear search
                     </a>
                     {# djlint:on #}
                 </p>
                 {% endif %}
+
             </div>
         </div>
     </div>

--- a/app/blueprints/assessments/templates/macros/team_dashboard_header.html
+++ b/app/blueprints/assessments/templates/macros/team_dashboard_header.html
@@ -1,0 +1,60 @@
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{% from "macros/logout_partial.html" import logout_partial %}
+
+{% macro render(round_details, stats, team_flag_stats, is_active_status) %}
+
+<header role="banner" data-module="govuk-header">
+    <nav class="govuk-width-container govuk-header__navigation">
+        <div class="govuk-phase-banner flex-parent-element">
+            <p class="govuk-!-text-align-left govuk-!-margin-left-3 flex-parent-element flexed-element-margins-collapse">
+                {{ govukBackLink({'href': url_for("assessment_bp.landing"), 'html': 'Back to <b>assessment landing</b>',
+                'attributes': {'data-qa': 'back-to-assessment-overview-link'} }) }}
+            </p>
+            {{ logout_partial(sso_logout_url) }}
+        </div>
+    </nav>
+
+    <div class="fsd-banner-background">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <div class="govuk-grid-column-two-thirds">
+                        <h1 class="govuk-heading-xl fsd-banner-content">Team dashboard</h1>
+                        {% if g.access_controller.is_lead_assessor %}
+                        <div class="govuk-body fsd-banner-content lead-dashboard-stats">
+                            {% if round_details["is_expression_of_interest"] %}
+                            <div class="lead-dashboard-stat">
+                                <p id="lead-dashboard-stat-assessments-qa-completed">{{ stats.qa_completed }}</p>
+                                <p class="lead-dashboard-stat-assessments-completed">QA complete</p>
+                            </div>
+                            {% endif %}
+                            <div class="lead-dashboard-stat">
+                                <p id="lead-dashboard-stat-assessments-total">{{ stats.total }}</p>
+                                <p>Assessments</p>
+                            </div>
+                            {% for team in team_flag_stats %}
+                            {% if team.raised > 0 and team.team_name %}
+                            <div class="lead-dashboard-stat">
+                                <p id="lead-dashboard-stat-assessments-total">{{ team.raised }}</p>
+                                <p>Total flagged for {{ team.team_name }}</p>
+                            </div>
+                            {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                        <h2 class="govuk-heading-l fsd-banner-content"> {% if is_active_status %}All active
+                            assessments{% else %}All closed assessments{% endif %}</h2>
+                        <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding"><strong>Fund: </strong>{{
+                            round_details["fund_name"] }}</p>
+                        {% if not round_details["is_expression_of_interest"] %}
+                        <p class="govuk-body-l fsd-banner-content"><strong>Round: </strong>{{
+                            round_details["round_title"] }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+
+{% endmacro %}

--- a/app/blueprints/assessments/templates/select_assessor.html
+++ b/app/blueprints/assessments/templates/select_assessor.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
+{% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% from "macros/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}Team dashboard{% endset %}
+
+{% block header %}
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
+{% endblock header %}
+
+{% block content %}
+{# CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
+
+
+<div class="govuk-grid-row">
+    {% if migration_banner_enabled %}
+    {{ migration_banner() }}
+    {% endif %}
+    <section id="select-assessors" class="govuk-width-container govuk-grid-column-full">
+        <header class="govuk-body">
+            <h1 class="govuk-heading-l">Assign assessments to general assessor</h1>
+        </header>
+        <p class="govuk-body">Select the user/s you would like to assign these assessments to</p>
+        <form method="post" action="{{ url_for("assessment_bp.landing") }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <p class="govuk-body">Showing {{ users|length }} users</p>
+            {% for assessment in selected_assessments %}
+                <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+            {% endfor %}
+            <input id="select_all_users" type="checkbox">
+            <label class="govuk-label govuk-checkboxes__label" for="select_all_users">Select all</label>
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Select</th>
+                        <th scope="col" class="govuk-table__header">Name</th>
+                        <th scope="col" class="govuk-table__header">Email</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for user in users %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            <input type="checkbox" name="selected_users" value="{{ email }}">
+                        </td>
+                        <td class="govuk-table__cell">{{ user["full_name"] }}</td>
+                        <td class="govuk-table__cell">{{ user["email_address"] }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <button class="govuk-button" type="submit">Continue</button>
+        </form>
+    </section>
+</div>
+{% endblock content %}

--- a/app/blueprints/assessments/templates/select_assessor.html
+++ b/app/blueprints/assessments/templates/select_assessor.html
@@ -27,35 +27,48 @@
         <header class="govuk-body">
             <h1 class="govuk-heading-l">Assign assessments to general assessor</h1>
         </header>
+        <div class="govuk-form-group {% if form.form_errors %} govuk-form-group--error {% endif %}">
         <p class="govuk-body">Select the user/s you would like to assign these assessments to</p>
-        <form method="post" action="{{ url_for("assessment_bp.landing") }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <p class="govuk-body">Showing {{ users|length }} users</p>
-            {% for assessment in selected_assessments %}
-                <input type="hidden" name="selected_assessments" value="{{ assessment }}">
-            {% endfor %}
-            <input id="select_all_users" type="checkbox">
-            <label class="govuk-label govuk-checkboxes__label" for="select_all_users">Select all</label>
-            <table class="govuk-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Select</th>
-                        <th scope="col" class="govuk-table__header">Name</th>
-                        <th scope="col" class="govuk-table__header">Email</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                    {% for user in users %}
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <input type="checkbox" name="selected_users" value="{{ email }}">
-                        </td>
-                        <td class="govuk-table__cell">{{ user["full_name"] }}</td>
-                        <td class="govuk-table__cell">{{ user["email_address"] }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+
+            <form method="post" action="{{ url_for('assessment_bp.assessor_type_list',
+                        fund_short_name=round_details.fund_short_name,
+                        round_short_name=round_details.round_short_name) }}">
+                {{ form.csrf_token }}
+                <p class="govuk-body">Showing {{ users|length }} users</p>
+                {% for assessment in selected_assessments %}
+                    <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+                {% endfor %}
+                <input type="hidden" name="assessor_role" value="{{ assessor_role }}">
+                {% if form.form_errors %}
+                <p class="govuk-error-message">
+                {% for error in form.form_errors %}
+                    <span class="govuk-visually-hidden">Error:</span> {{ error }}
+                {% endfor %}
+                </p>
+                {% endif %}
+                <input id="select_all_users" type="checkbox">
+                <label class="govuk-label govuk-checkboxes__label" for="select_all_users">Select all</label>
+                <table class="govuk-table">
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header">Select</th>
+                            <th scope="col" class="govuk-table__header">Name</th>
+                            <th scope="col" class="govuk-table__header">Email</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        {% for user in users %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                <input type="checkbox" name="selected_users" value="{{ user["account_id"] }}" {% if user["account_id"] in selected_users %}checked{% endif %}>
+                            </td>
+                            <td class="govuk-table__cell">{{ user["full_name"] }}</td>
+                            <td class="govuk-table__cell">{{ user["email_address"] }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+        </div>
             <button class="govuk-button" type="submit">Continue</button>
         </form>
     </section>

--- a/app/blueprints/assessments/templates/select_assessor.html
+++ b/app/blueprints/assessments/templates/select_assessor.html
@@ -34,7 +34,7 @@
                         fund_short_name=round_details.fund_short_name,
                         round_short_name=round_details.round_short_name) }}">
                 {{ form.csrf_token }}
-                <p class="govuk-body">Showing {{ users|length }} users</p>
+                <p class="govuk-body">Showing {{ users|length }} user{{ "s" if users|length > 2 else "" }}</p>
                 {% for assessment in selected_assessments %}
                     <input type="hidden" name="selected_assessments" value="{{ assessment }}">
                 {% endfor %}

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -94,6 +94,16 @@ def call_search_applications(params: dict | str):
     return applications_response
 
 
+def get_application_assignments(application_id):
+    application_assignments_endpoint = Config.ASSESSMENT_ASSIGNED_USERS_ENDPOINT.format(
+        application_id=application_id
+    )
+    current_app.logger.info(f"Endpoint '{application_assignments_endpoint}'.")
+    response = get_data(application_assignments_endpoint)
+
+    return response
+
+
 def get_application_overviews(fund_id, round_id, search_params):
     overviews_endpoint = (
         Config.ASSESSMENT_STORE_API_HOST

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -106,13 +106,28 @@ def get_application_overviews(fund_id, round_id, search_params):
     return overviews_response
 
 
-def get_users_for_fund(fund_short_name):
+def get_users_for_fund(
+    fund_short_name,
+    round_short_name=None,
+    include_assessors=None,
+    include_commenters=None,
+):
+    query_params = {}
+    if round_short_name:
+        query_params["round_short_name"] = round_short_name
+
+    if include_assessors:
+        query_params["include_assessors"] = include_assessors
+
+    if include_commenters:
+        query_params["include_commenters"] = include_commenters
+
     users_for_fund = (Config.ACCOUNT_STORE_API_HOST) + Config.USER_FUND_ENDPOINT.format(
         fund_short_name=fund_short_name
     )
 
     current_app.logger.info(f"Endpoint '{users_for_fund}'.")
-    users_for_fund_response = get_data(users_for_fund)
+    users_for_fund_response = get_data(users_for_fund, query_params)
 
     return users_for_fund_response
 

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -844,3 +844,30 @@ def get_scoring_system(round_id: str) -> List[Flag]:
     current_app.logger.info(f"Calling endpoint '{scoring_endpoint}'.")
     scoring_system = get_data(scoring_endpoint)["scoring_system"]
     return scoring_system
+
+
+def assign_user_to_assessment(
+    application_id: str, user_id: str, assigner_id: str, update: Optional[bool] = False
+):
+    """Creates a user association between a user and an application.
+    Internally, this is how we assign a user to an assessment.
+
+    :param application_id: The application to be assigned
+    :param user_id: The id of the user to be assigned
+    :param assigner_id: The id of the user who is creating the assignment
+    :param update: update assignment if it already exists
+    """
+    assignment_endpoint = Config.ASSESSMENT_ASSOCIATE_USER_ENDPOINT.format(
+        application_id=application_id, user_id=user_id
+    )
+    if update:
+        response = requests.put(assignment_endpoint, json={"active": "true"})
+    else:
+        response = requests.post(assignment_endpoint, json={"assigner_id": assigner_id})
+    if not response.ok:
+        current_app.logger.error(
+            f"Could not get assign user {user_id} to application {application_id}"
+        )
+        return None
+
+    return response.json()

--- a/app/blueprints/shared/filters.py
+++ b/app/blueprints/shared/filters.py
@@ -80,6 +80,10 @@ def all_caps_to_human(word):
         return result.capitalize()
 
 
+def add_to_dict(x, y):
+    return dict(x, **y)
+
+
 def format_project_ref(value: str):
     secions = value.split("-")
     return secions[len(secions) - 1]

--- a/app/static/src/js/helpers.js
+++ b/app/static/src/js/helpers.js
@@ -66,3 +66,24 @@ Array.from(tabAnchors).forEach(tabAnchor => {
         }
     });
 })
+
+
+const select_all_assessments = document.getElementById('select_all_for_assignment')
+if (select_all_assessments) {
+  select_all_assessments.addEventListener('change', function(e) {
+    var checkboxes = document.querySelectorAll('input[name="selected_assessments"]');
+    checkboxes.forEach(function(checkbox) {
+      checkbox.checked = e.target.checked;
+    });
+  });
+}
+
+const select_all_users = document.getElementById('select_all_users')
+if (select_all_users) {
+  select_all_users.addEventListener('change', function(e) {
+    var checkboxes = document.querySelectorAll('input[name="selected_users"]');
+    checkboxes.forEach(function(checkbox) {
+        checkbox.checked = e.target.checked;
+    });
+  });
+}

--- a/app/static/src/styles/govuk-overrides.css
+++ b/app/static/src/styles/govuk-overrides.css
@@ -163,6 +163,16 @@
     letter-spacing: normal;
 }
 
+.btn-link {
+    border: none;
+    padding: 0;
+    color: #069;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 400
+}
+
 .primary-button {
     margin-bottom: 0;
     background-color: #1d70b8;

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -229,6 +229,11 @@ class DefaultConfig:
         ASSESSMENT_STORE_API_HOST + "/scoring-system/{round_id}"
     )
 
+    # Roles
+
+    LEAD_ASSESSOR = "LEAD_ASSESSOR"
+    ASSESSOR = "ASSESSOR"
+
     # Account store endpoints
     BULK_ACCOUNTS_ENDPOINT = ACCOUNT_STORE_API_HOST + "/bulk-accounts"
     USER_FUND_ENDPOINT = "/accounts/fund/{fund_short_name}"
@@ -326,7 +331,7 @@ class DefaultConfig:
     # Redis Feature Toggle Configuration
     REDIS_INSTANCE_URI = getenv("REDIS_INSTANCE_URI", "redis://localhost:6379")
     TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
-    FEATURE_CONFIG = {"TAGGING": True}
+    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": False}
     ASSETS_AUTO_BUILD = False
 
     # LRU cache settings

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -187,6 +187,14 @@ class DefaultConfig:
     )
     ASSESSMENT_TAG_TYPES_ENDPOINT = ASSESSMENT_STORE_API_HOST + "/tag_types"
 
+    ASSESSMENT_ASSOCIATE_USER_ENDPOINT = (
+        ASSESSMENT_STORE_API_HOST + "/application/{application_id}/user/{user_id}"
+    )
+
+    ASSESSMENT_ASSIGNED_USERS_ENDPOINT = (
+        ASSESSMENT_STORE_API_HOST + "/application/{application_id}/users"
+    )
+
     APPLICANT_EXPORT_ENDPOINT = (
         ASSESSMENT_STORE_API_HOST
         + "/application_fields_export/{fund_id}/{round_id}/{report_type}"

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -82,7 +82,7 @@ class DevelopmentConfig(DefaultConfig):
     AWS_BUCKET_NAME = getenv("AWS_BUCKET_NAME")
     AWS_REGION = "eu-west-2"
 
-    FEATURE_CONFIG = {"TAGGING": True}
+    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": True}
     ASSETS_AUTO_BUILD = True
 
     # LRU cache settings

--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -7,3 +7,4 @@ from config.envs.default import DefaultConfig
 class TestConfig(DefaultConfig):
     # LRU cache settings
     LRU_CACHE_TIME = 300  # in seconds
+    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": True}

--- a/create_app.py
+++ b/create_app.py
@@ -28,6 +28,7 @@ from app.blueprints.assessments.routes import assessment_bp
 from app.blueprints.authentication.auth import auth_protect
 from app.blueprints.flagging.routes import flagging_bp
 from app.blueprints.scoring.routes import scoring_bp
+from app.blueprints.shared.filters import add_to_dict
 from app.blueprints.shared.filters import all_caps_to_human
 from app.blueprints.shared.filters import ast_literal_eval
 from app.blueprints.shared.filters import datetime_format
@@ -94,6 +95,7 @@ def create_app() -> Flask:
         flask_app.jinja_env.filters["ast_literal_eval"] = ast_literal_eval
         flask_app.jinja_env.filters["datetime_format"] = datetime_format
         flask_app.jinja_env.filters["utc_to_bst"] = utc_to_bst
+        flask_app.jinja_env.filters["add_to_dict"] = add_to_dict
         flask_app.jinja_env.filters["slash_separated_day_month_year"] = (
             slash_separated_day_month_year
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import jwt as jwt
 import pytest
+import werkzeug.test
 from flask import template_rendered
 
 from app.blueprints.assessments.models.round_status import RoundStatus
@@ -145,6 +146,28 @@ def flask_test_client(app, user_token=None):
             user_token or create_valid_token(),
         )
         yield test_client
+
+
+def resolve_redirect_path(self, response, buffered=False):
+    # Custom logic here
+    response.request.environ["wsgi.input"].seek(0)
+
+    # Call the original resolve_redirect method
+    return self._original_resolve_redirect(response, buffered=buffered)
+
+
+@pytest.fixture
+def patch_resolve_redirect():
+    # Store the original resolve_redirect method
+    werkzeug.test.Client._original_resolve_redirect = (
+        werkzeug.test.Client.resolve_redirect
+    )
+
+    # Patch the resolve_redirect method with resolve_redirect_path
+    with mock.patch.object(
+        werkzeug.test.Client, "resolve_redirect", new=resolve_redirect_path
+    ):
+        yield
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,0 +1,446 @@
+import re
+from unittest import mock
+
+import pytest
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from tests.api_data.test_data import fund_specific_claim_map
+from tests.conftest import create_valid_token
+
+
+# Test assign_assessments route
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": {
+            "search_term": "",
+            "search_in": "project_name,short_id",
+            "assigned_to": "ALL",
+            "asset_type": "ALL",
+            "status": "ALL",
+            "filter_by_tag": "ALL",
+        },
+    }
+)
+def test_assign_assessments_get(
+    request,
+    flask_test_client,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_fund,
+    mock_get_application_overviews,
+    mock_get_users_for_fund,
+    mock_get_assessment_progress,
+    mock_get_application_metadata,
+    mock_get_active_tags_for_fund_round,
+    mock_get_tag_types,
+):
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    flask_test_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]),
+    )
+
+    response = flask_test_client.get(
+        url_for(
+            "assessment_bp.assign_assessments",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+        )
+    )
+
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    # Check that there is a "select all" checkbox
+    select_all_checkbox = soup.find(
+        "input", {"type": "checkbox", "id": "select_all_for_assignment"}
+    )
+    assert select_all_checkbox is not None, "Select all checkbox is missing"
+
+    # Check that there is a checkbox for each project
+    project_checkboxes = soup.find_all(
+        "input", {"type": "checkbox", "name": "selected_assessments"}
+    )
+    assert (
+        len(project_checkboxes) == 4
+    ), f"Expected 4 project checkboxes, found {len(project_checkboxes)}"
+
+    assert response.status_code == 200
+    assert b"Assign assessments" in response.data
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": "",
+    }
+)
+def test_assign_assessments_post(
+    request,
+    flask_test_client,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_fund,
+    mock_get_application_overviews,
+    mock_get_users_for_fund,
+    patch_resolve_redirect,
+):
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    flask_test_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]),
+    )
+
+    form_data = {
+        "selected_assessments": ["assessment1", "assessment2"],
+    }
+
+    headers = {
+        "Referer": url_for(
+            "assessment_bp.assign_assessments",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+            _external=True,
+        ),
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    response = flask_test_client.post(
+        url_for(
+            "assessment_bp.assign_assessments",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+        ),
+        headers=headers,
+        data=form_data,
+        follow_redirects=True,
+    )
+
+    # Check that there are two radio buttons, one for general assessor and one for lead assessor
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    # Check form data has been processed and stored as hidden fields.
+    hidden_fields = soup.find_all(
+        "input", {"type": "hidden", "name": "selected_assessments"}
+    )
+    assert hidden_fields[0].get("value") == "assessment1"
+    assert hidden_fields[1].get("value") == "assessment2"
+
+    radio_buttons = soup.find_all("input", {"type": "radio"})
+
+    assert (
+        len(radio_buttons) == 2
+    ), f"Expected 2 radio buttons, found {len(radio_buttons)}"
+
+    radio_values = [radio.get("value") for radio in radio_buttons]
+    assert (
+        "general_assessor" in radio_values
+    ), "Radio button for 'general_assessor' not found"
+    assert "lead_assessor" in radio_values, "Radio button for 'lead_assessor' not found"
+
+    assert response.status_code == 200
+    assert b"Select the type of role you would like to assign." in response.data
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": "",
+    }
+)
+def test_assessor_type_post(
+    request,
+    flask_test_client,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_fund,
+    mock_get_application_overviews,
+    mock_get_users_for_fund,
+    patch_resolve_redirect,
+):
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    flask_test_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]),
+    )
+
+    form_data = {
+        "selected_assessments": ["assessment1"],
+        "assessor_role": ["lead_assessor"],
+    }
+
+    headers = {
+        "Referer": url_for(
+            "assessment_bp.assessor_type",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+            _external=True,
+        ),
+    }
+    response = flask_test_client.post(
+        url_for(
+            "assessment_bp.assessor_type",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+        ),
+        headers=headers,
+        data=form_data,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    # Check form data has been processed and stored as hidden fields.
+    for key, value in form_data.items():
+        hidden_field = soup.find("input", {"type": "hidden", "name": key})
+        assert hidden_field is not None
+        assert hidden_field.get("value") == value[0]
+
+    # Check for the "select all" checkbox
+    select_all_checkbox = soup.find(
+        "input", {"id": "select_all_users", "type": "checkbox"}
+    )
+    assert select_all_checkbox is not None, "Select all checkbox not found"
+
+    table_body = soup.find("tbody", class_="govuk-table__body")
+    assert table_body is not None, "Table body not found"
+
+    # Check there is only a single assignable user ("Lead Test User")
+    rows = table_body.find_all("tr", class_="govuk-table__row")
+    assert len(rows) == 1, f"Expected 1 row, found {len(rows)}"
+
+    row = rows[0]
+
+    name_cell = row.find_all("td", class_="govuk-table__cell")[1]
+    assert (
+        fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]["fullName"]
+        in name_cell.text.strip()
+    ), f"Expected 'Lead Test User', found {name_cell.text.strip()}"
+
+    # Check that there is a checkbox for this entry
+    checkbox = row.find(
+        "input",
+        {
+            "type": "checkbox",
+            "name": "selected_users",
+            "value": fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"][
+                "accountId"
+            ],
+        },
+    )
+    assert (
+        checkbox is not None
+    ), f"Checkbox for {fund_specific_claim_map[fund_short_name]['LEAD_ASSESSOR']['accountId']} not found"
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": "",
+    }
+)
+def test_assessor_type_list_post(
+    request,
+    flask_test_client,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_fund,
+    mock_get_application_overviews,
+    mock_get_users_for_fund,
+    mock_get_assessment_progress,
+    patch_resolve_redirect,
+):
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    flask_test_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]),
+    )
+
+    form_data = {
+        "selected_assessments": ["stopped_app"],
+        "assessor_role": ["general_assessor"],
+        "selected_users": [
+            fund_specific_claim_map[fund_short_name]["ASSESSOR"]["accountId"]
+        ],
+    }
+    headers = {
+        "Referer": url_for(
+            "assessment_bp.assessor_type_list",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+            _external=True,
+        ),
+    }
+    response = flask_test_client.post(
+        url_for(
+            "assessment_bp.assessor_type_list",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+        ),
+        data=form_data,
+        headers=headers,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    # Check form data has been processed and stored as hidden fields.
+    for key, value in form_data.items():
+        hidden_field = soup.find("input", {"type": "hidden", "name": key})
+        assert hidden_field is not None
+        assert hidden_field.get("value") == value[0]
+
+    # Check get_assessment_progress() is only called for the selected assessments
+    assert len(mock_get_assessment_progress.call_args[0][0]) == 1
+    assert (
+        mock_get_assessment_progress.call_args[0][0][0]["application_id"]
+        == form_data["selected_assessments"][0]
+    )
+    strip_html_regx = re.compile("<.*?>")
+    html_stripped_output = re.sub(strip_html_regx, "", str(response.data))
+    assert (
+        f"You are about to assign {fund_specific_claim_map[fund_short_name]['ASSESSOR']['fullName']}"
+        " to 1 assessment as a general assessor" in html_stripped_output
+    )
+
+
+@pytest.mark.mock_parameters(
+    {
+        "fund_short_name": "COF",
+        "round_short_name": "TR",
+        "expected_search_params": {
+            "search_term": "",
+            "search_in": "project_name,short_id",
+            "asset_type": "ALL",
+            "status": "ALL",
+            "filter_by_tag": "ALL",
+            "assigned_to": "ALL",
+        },
+    }
+)
+def test_assignment_overview_post(
+    request,
+    flask_test_client,
+    mock_get_funds,
+    mock_get_round,
+    mock_get_fund,
+    mock_get_application_overviews,
+    mock_get_users_for_fund,
+    mock_get_assessment_progress,
+    mock_get_application_metadata,
+    mock_get_active_tags_for_fund_round,
+    mock_get_tag_types,
+):
+
+    params = request.node.get_closest_marker("mock_parameters").args[0]
+    fund_short_name = params["fund_short_name"]
+    round_short_name = params["round_short_name"]
+
+    flask_test_client.set_cookie(
+        "localhost",
+        "fsd_user_token",
+        create_valid_token(fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"]),
+    )
+
+    form_data = {
+        "selected_assessments": ["assessment1", "assessment2"],
+        "assessor_role": ["lead_assessor"],
+        "selected_users": ["user1", "user2"],
+    }
+
+    headers = {
+        "Referer": url_for(
+            "assessment_bp.assignment_overview",
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+            _external=True,
+        ),
+    }
+    with mock.patch(
+        "app.blueprints.assessments.routes.get_application_assignments",
+        return_value=[{"user_id": "user2"}],
+    ), mock.patch(
+        "app.blueprints.assessments.routes.assign_user_to_assessment",
+    ) as mock_assign_user_to_assessment_1:
+        response = flask_test_client.post(
+            url_for(
+                "assessment_bp.assignment_overview",
+                fund_short_name=fund_short_name,
+                round_short_name=round_short_name,
+            ),
+            data=form_data,
+            headers=headers,
+            follow_redirects=True,
+        )
+
+        # For User 1 this is a new assignment, for User 2 this is an existing assignment that should be activated.
+        mock_assign_user_to_assessment_1.assert_has_calls(
+            [
+                mock.call(
+                    "assessment1",
+                    "user1",
+                    fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"][
+                        "accountId"
+                    ],
+                    False,
+                ),
+                mock.call(
+                    "assessment2",
+                    "user1",
+                    fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"][
+                        "accountId"
+                    ],
+                    False,
+                ),
+                mock.call(
+                    "assessment1",
+                    "user2",
+                    fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"][
+                        "accountId"
+                    ],
+                    True,
+                ),
+                mock.call(
+                    "assessment2",
+                    "user2",
+                    fund_specific_claim_map[fund_short_name]["LEAD_ASSESSOR"][
+                        "accountId"
+                    ],
+                    True,
+                ),
+            ],
+            any_order=True,
+        )
+
+        assert len(mock_assign_user_to_assessment_1.mock_calls) == 4
+
+    assert response.status_code == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -167,7 +167,6 @@ class TestRoutes:
         )
 
         assert 200 == response.status_code, "Wrong status code on response"
-        mock_get_users_for_fund.assert_called_with(fund_short_name)
         soup = BeautifulSoup(response.data, "html.parser")
 
         all_table_headings = str(soup.find_all("th", class_="govuk-table__header"))


### PR DESCRIPTION
### Change description
This PR covers several views to enable lead assessors to assign assessments to other lead or general assessors. Things to note:
- The actual assignments are only created after submission on the final page (assignment_overview). The views prior to this only store user selections via hidden input fields (persistent storage is not used until the final submission). 
- This development only covers the ability to assign users to assessments (un-assignment will be covered in another ticket).
- The search bar and 'Team' column are no longer needed. The optional comment field will be covered in another ticket.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Follow the figma flow in the ticket to test the workflow and views. 


### Screenshots of UI changes (if applicable)
<img width="1281" alt="Screenshot 2024-08-13 at 11 04 14" src="https://github.com/user-attachments/assets/331dd205-5a18-41b1-a6c7-07364c1134de">
<img width="1287" alt="Screenshot 2024-08-13 at 11 04 23" src="https://github.com/user-attachments/assets/44eb1e1d-86bb-46a2-88d8-f71e130b5c73">
<img width="833" alt="Screenshot 2024-08-13 at 11 45 56" src="https://github.com/user-attachments/assets/c8381451-070a-45ec-8595-17a93dd614e0">
<img width="793" alt="Screenshot 2024-08-13 at 11 46 12" src="https://github.com/user-attachments/assets/3e9f60ab-ac5b-459f-b01f-e87d8f56866f">
<img width="1282" alt="Screenshot 2024-08-13 at 11 46 39" src="https://github.com/user-attachments/assets/322117ec-3b84-4474-92b3-236d6ab06967">

