### PR TITLE
Only allow a single assessment to be selected for assignment

### DIFF
--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -9,14 +9,17 @@ class AssessmentAssignmentForm(FlaskForm):
                 # From a redirect, not a form post
                 return False
 
-            if not request.form.getlist("selected_assessments"):
+            if not (
+                selected_assessments := request.form.getlist("selected_assessments")
+            ):
                 self.form_errors.append("At least one assessment should be selected")
                 return False
-            else:
-                if len(request.form.getlist("selected_assessments")) > 1:
-                    self.form_errors.append("At most one assessment should be selected")
-                    return False
-                return True
+
+            if len(selected_assessments) > 1:
+                self.form_errors.append("At most one assessment should be selected")
+                return False
+
+            return True
 
         return False
 
@@ -31,8 +34,8 @@ class AssessorTypeForm(FlaskForm):
             if not request.form.getlist("assessor_role"):
                 self.form_errors.append("An assessor type should be selected")
                 return False
-            else:
-                return True
+
+            return True
 
         return False
 
@@ -51,8 +54,8 @@ class AssessorChoiceForm(FlaskForm):
                     "No changes have been made to the current assignments for this application"
                 )
                 return False
-            else:
-                return True
+
+            return True
 
         return False
 

--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -13,6 +13,9 @@ class AssessmentAssignmentForm(FlaskForm):
                 self.form_errors.append("At least one assessment should be selected")
                 return False
             else:
+                if len(request.form.getlist("selected_assessments")) > 1:
+                    self.form_errors.append("At most one assessment should be selected")
+                    return False
                 return True
 
         return False
@@ -41,8 +44,12 @@ class AssessorChoiceForm(FlaskForm):
                 # From a redirect, not a form post
                 return False
 
-            if not request.form.getlist("selected_users"):
-                self.form_errors.append("At least one assessor should be selected")
+            if set(request.form.getlist("assigned_users")) == set(
+                request.form.getlist("selected_users")
+            ):
+                self.form_errors.append(
+                    "No changes have been made to the current assignments for this application"
+                )
                 return False
             else:
                 return True

--- a/app/blueprints/assessments/templates/assessor_type.html
+++ b/app/blueprints/assessments/templates/assessor_type.html
@@ -27,6 +27,22 @@
         <header class="govuk-body">
             <h1 class="govuk-heading-l">Assign to lead assessor or general assessor</h1>
         </header>
+        {% if form.form_errors %}
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+            <h2 class="govuk-error-summary__title">
+            There is a problem
+            </h2>
+            <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+                {% for error in form.form_errors %}
+                <li><a href="#assessor-type-selection">{{ error }}</a></li>
+                {% endfor %}
+            </ul>
+            </div>
+        </div>
+        </div>
+        {% endif %}
         <div class="govuk-form-group {% if form.form_errors %} govuk-form-group--error {% endif %}">
             {% if form.form_errors %}
             <p class="govuk-error-message">
@@ -43,7 +59,7 @@
                 {% for assessment in selected_assessments %}
                 <input type="hidden" name="selected_assessments" value="{{ assessment }}">
                 {% endfor %}
-                <div class="govuk-radios">
+                <div class="govuk-radios" id="assessor-type-selection">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="lead_assessor" name="assessor_role" type="radio" value="lead_assessor" {% if selected_assessor_role == "lead_assessor" %}checked{% endif %}>
                         <label class="govuk-label govuk-radios__label" for="lead_assessor">

--- a/app/blueprints/assessments/templates/assign_assessments.html
+++ b/app/blueprints/assessments/templates/assign_assessments.html
@@ -27,7 +27,7 @@
     <header class="govuk-body ">
         <h1 class="govuk-heading-l">Assign assessments</h1>
     </header>
-    <p class="govuk-body">Select the assessments you would like to assign to others</p>
+    <p class="govuk-body">Select the assessment you would like to assign to others</p>
     {% endmacro -%}
     <section id="application-overview" class="govuk-width-container govuk-grid-column-full">
         {{ ApplicationsOverviewHtmlBase("All applications") }}

--- a/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
+++ b/app/blueprints/assessments/templates/macros/application_overviews_table_all.html
@@ -7,6 +7,24 @@
 {% macro render(application_overviews, round_details, query_params, asset_types,
 assessment_statuses, display_config,
 sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users) -%}
+
+{% if display_config["assessment_form"] and display_config["assessment_form"].form_errors %}
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        {% for error in display_config["assessment_form"].form_errors %}
+        <li><a href="#application_overviews_table">{{ error }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <nav class="search-bar-flex-container">
   <form method="get" class="govuk-!-width-full">
     {{ filter_options(
@@ -39,20 +57,13 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users)
                       round_short_name=round_details.round_short_name) }}">
     {{ display_config["assessment_form"].csrf_token }}
   {% endif %}
-  <table class="govuk-table govuk-!-margin-top-4" id="application_overviews_table">
+  <table class="govuk-table govuk-!-margin-top-4 {% if display_config["assessment_form"] and display_config["assessment_form"].form_errors %} govuk-form-group--error {% endif %}" id="application_overviews_table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         {% if display_config["assessment_form"] %}
         <th scope="col" class="govuk-table__header">
-          <input type="checkbox" id="select_all_for_assignment" />
+          Select
         </th>
-          {% if display_config["assessment_form"].form_errors %}
-            <ul class="errors">
-            {% for error in display_config["assessment_form"].form_errors %}
-                <li>{{ error }}</li>
-            {% endfor %}
-            </ul>
-          {% endif %}
         {% endif %}
         <th scope="col" class="govuk-table__header">
           Reference

--- a/app/blueprints/assessments/templates/select_assessor.html
+++ b/app/blueprints/assessments/templates/select_assessor.html
@@ -65,6 +65,8 @@
                 {% endfor %}
                 </p>
                 {% endif %}
+                <input id="select_all_users" type="checkbox">
+                <label class="govuk-label govuk-checkboxes__label" for="select_all_users">Select all</label>
                 <table class="govuk-table {% if form.form_errors %} govuk-form-group--error {% endif %}" id="assessor-selection">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">

--- a/app/blueprints/assessments/templates/select_assessor.html
+++ b/app/blueprints/assessments/templates/select_assessor.html
@@ -25,10 +25,26 @@
     {% endif %}
     <section id="select-assessors" class="govuk-width-container govuk-grid-column-full">
         <header class="govuk-body">
-            <h1 class="govuk-heading-l">Assign assessments to general assessor</h1>
+            <h1 class="govuk-heading-l">Assign assessment to {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor</h1>
         </header>
-        <div class="govuk-form-group {% if form.form_errors %} govuk-form-group--error {% endif %}">
-        <p class="govuk-body">Select the user/s you would like to assign these assessments to</p>
+        {% if form.form_errors %}
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+            <h2 class="govuk-error-summary__title">
+            There is a problem
+            </h2>
+            <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+                {% for error in form.form_errors %}
+                <li><a href="#assessor-selection">{{ error }}</a></li>
+                {% endfor %}
+            </ul>
+            </div>
+        </div>
+        </div>
+        {% endif %}
+        <div class="govuk-form-group">
+        <p class="govuk-body">Select the user/s you would like to assign this assessment to</p>
 
             <form method="post" action="{{ url_for('assessment_bp.assessor_type_list',
                         fund_short_name=round_details.fund_short_name,
@@ -38,6 +54,9 @@
                 {% for assessment in selected_assessments %}
                     <input type="hidden" name="selected_assessments" value="{{ assessment }}">
                 {% endfor %}
+                {% for user_id in assigned_users %}
+                    <input type="hidden" name="assigned_users" value="{{ user_id }}">
+                {% endfor %}
                 <input type="hidden" name="assessor_role" value="{{ assessor_role }}">
                 {% if form.form_errors %}
                 <p class="govuk-error-message">
@@ -46,9 +65,7 @@
                 {% endfor %}
                 </p>
                 {% endif %}
-                <input id="select_all_users" type="checkbox">
-                <label class="govuk-label govuk-checkboxes__label" for="select_all_users">Select all</label>
-                <table class="govuk-table">
+                <table class="govuk-table {% if form.form_errors %} govuk-form-group--error {% endif %}" id="assessor-selection">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
                             <th scope="col" class="govuk-table__header">Select</th>


### PR DESCRIPTION
### Change description
Follow on from https://github.com/communitiesuk/funding-service-design-assessment/pull/670/files.

An update in the ticket requires that only one assessment can be selected for assignment at a time. This PR updates the validation handling and error messaging. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
