### PR TITLE
FS-4082 Add pagination logic for sections on an application

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -1062,6 +1062,7 @@ def display_sub_criteria(
         "current_theme": current_theme,
         "flag_status": flag_status,
         "assessment_status": assessment_status,
+        "pagination": state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     }
 
     theme_answers_response = get_sub_criteria_theme_answers_all(

--- a/app/blueprints/assessments/templates/sub_criteria.html
+++ b/app/blueprints/assessments/templates/sub_criteria.html
@@ -8,6 +8,7 @@
 {% from "macros/comments_box.html" import comment_box %}
 {% from "macros/sub_criteria_heading.html" import sub_criteria_heading %}
 {% from "macros/migration_banner.html" import migration_banner %}
+{%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
 
 {% set pageHeading -%}
 {% if comment_form.comment.errors %}
@@ -87,6 +88,20 @@ Error:
                 {% if display_comment_edit_box %}
                     {{ edit_comment_box(comments, comment_id, comment_form)}}
                 {% endif %}
+
+                {{ govukPagination({
+                    "previous": pagination.previous and {
+                        "labelText": pagination.previous.sub_section_name,
+                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.previous.sub_section_id)
+                    },
+                    "next": {
+                        "labelText": pagination.next.sub_section_name,
+                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.next.sub_section_id)
+                    } if pagination.next else {
+                        "labelText": "Back to assessment task list",
+                        "href": url_for("assessment_bp.application", application_id=application_id)
+                    }
+                }) }}
         </div>
 </div>
 {% endblock content %}

--- a/app/blueprints/services/models/assessor_task_list.py
+++ b/app/blueprints/services/models/assessor_task_list.py
@@ -168,3 +168,20 @@ class AssessorTaskList:
                 return item
 
         return None
+
+    def get_pagination_from_sub_criteria_id(self, sub_criteria_id):
+        sections = self.get_sub_sections_metadata()
+        index = {
+            section["sub_section_id"]: get_page(i, sections)
+            for i, section in enumerate(sections)
+        }
+        return index.get(sub_criteria_id)
+
+
+def get_page(index, sections):
+    has_previous_elements = index > 0
+    has_next_elements = index < len(sections) - 1
+    return dict(
+        previous=has_previous_elements and sections[index - 1],
+        next=has_next_elements and sections[index + 1],
+    )

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -628,7 +628,7 @@ mock_api_results = {
         "sections": [
             {
                 "name": "string",
-                "sub_criterias": [{"id": "string", "name": "string"}],
+                "sub_criterias": [{"id": "string", "name": "A fixed sub criteria"}],
             }
         ],
         "project_name": resolved_app["project_name"],

--- a/tests/test_shared_helpers.py
+++ b/tests/test_shared_helpers.py
@@ -1,0 +1,124 @@
+import pytest
+
+from app.blueprints.services.models.assessor_task_list import AssessorTaskList
+from app.blueprints.services.shared_data_helpers import get_state_for_tasklist_banner
+
+
+def mock_task_list(sections=[], criterias=[]):
+    return AssessorTaskList.from_json({"sections": sections, "criterias": criterias})
+
+
+@pytest.mark.application_id("resolved_app")
+@pytest.mark.sub_criteria_id("test_sub_criteria_id")
+def test_pagination_helper_should_parse_with_real_backend_data(
+    mock_get_sub_criteria,
+    mock_get_fund,
+    mock_get_round,
+    mock_get_assessor_tasklist_state,
+):
+    # make sure the helper appropriately loads and parses pagination from backend services by mocking out those calls
+    state = get_state_for_tasklist_banner("resolved_app")
+    pagination = state.get_pagination_from_sub_criteria_id("test_sub_criteria_id")
+
+    assert pagination["previous"]["sub_section_name"] == "A fixed sub criteria"
+    assert pagination["next"] is False
+
+
+def test_pagination_should_be_none_for_missing_section_id():
+    state = mock_task_list(sections=[], criterias=[])
+    assert state.get_pagination_from_sub_criteria_id("missing-sub-criteria-id") is None
+
+
+def test_pagination_should_be_empty_with_only_one_section():
+    state = mock_task_list(
+        sections=[
+            {
+                "name": "first-group",
+                "sub_criterias": [{"id": "first-section", "name": "A sub criteria"}],
+            }
+        ],
+    )
+    pagination = state.get_pagination_from_sub_criteria_id("first-section")
+    assert pagination["previous"] is False
+    assert pagination["next"] is False
+
+
+multiple_sections_state = mock_task_list(
+    sections=[
+        {
+            "name": "first-group",
+            "sub_criterias": [
+                {"id": "first-section", "name": "A sub criteria"},
+                {"id": "second-section", "name": "A second sub criteria"},
+                {"id": "third-section", "name": "A third sub criteria"},
+            ],
+        },
+        {
+            "name": "second-group",
+            "sub_criterias": [
+                {
+                    "id": "first-section-second-group",
+                    "name": "A sub criteria for the second group",
+                },
+            ],
+        },
+    ],
+    # Note that sections and criterias are treated the same on the task list detail page
+    criterias=[
+        {
+            "name": "first-group-criterias",
+            "sub_criterias": [
+                {
+                    "id": "criteria-id",
+                    "name": "A first criteria name",
+                    "theme_count": 1,
+                    "score": 4,
+                    "status": "string",
+                },
+                {
+                    "id": "second-criteria-id",
+                    "name": "A second criteria name",
+                    "theme_count": 1,
+                    "score": 4,
+                    "status": "string",
+                },
+            ],
+            "total_criteria_score": 4,
+            "number_of_scored_sub_criteria": 5,
+            "weighting": 0,
+        }
+    ],
+)
+
+
+def test_pagination_should_have_empty_previous_when_loading_first_section():
+    pagination = multiple_sections_state.get_pagination_from_sub_criteria_id(
+        "first-section"
+    )
+    assert pagination["previous"] is False
+    assert pagination["next"]["sub_section_id"] == "second-section"
+
+
+def test_pagination_should_have_empty_next_when_loading_last_section():
+    pagination = multiple_sections_state.get_pagination_from_sub_criteria_id(
+        "second-criteria-id"
+    )
+    assert pagination["previous"]["sub_section_id"] == "criteria-id"
+    assert pagination["next"] is False
+
+
+def test_pagination_should_have_previous_next_when_loading_within_section_group():
+    pagination = multiple_sections_state.get_pagination_from_sub_criteria_id(
+        "second-section"
+    )
+    assert pagination["previous"]["sub_section_id"] == "first-section"
+    assert pagination["next"]["sub_section_id"] == "third-section"
+
+
+def test_pagination_should_have_previous_next_when_loading_across_section_groups():
+    # This should get the last section from the first group and the first section from the critereas group
+    pagination = multiple_sections_state.get_pagination_from_sub_criteria_id(
+        "first-section-second-group"
+    )
+    assert pagination["previous"]["sub_section_id"] == "third-section"
+    assert pagination["next"]["sub_section_id"] == "criteria-id"


### PR DESCRIPTION
### Change description
On the application detail page (task list into individual sections), allow moving between section detail pages with a next/ previous pagination component.

We use the govuk design system `pagination` component which is supported by our pinned version of the design system and the jinja component library used.

The `state` dictionary which is consumed by every detail route describes the application and the assessors progress through it, as it already loaded information on all of the sections this seemed like a good place to add a utility for pagination. This utility can then also be used anywhere future tickets may need to move forwards and backwards between sections.

This learns from the functionality but deviates from the implementation of a [work in progress branch](https://github.com/communitiesuk/funding-service-design-assessment/tree/FS-4082-assessments-list--prev-next-links-v1) in a number of ways:
- as the information on sections already seems like it has been fetched to load the page (through the `state` abstraction), adding an accessor to this existing class we should benefit 
  - less HTTP calls, some of which are dependant on the size of the application
  - avoid fetching application details where they won't be used on the page (potentially easy to leak into logs or the template if future devs aren't aware of this)
  - configure the business logic somewhere that should be easier to cover with smaller tests - allow the forward/ backwards logic to be used anywhere that sections are mentioned in the future
- takes the next and previous logic out of the template to make it easier to cover
- removes any query strings used for logic, the aim is to make loading the pages independant of any outside state and simplify the URLs that users might be passing around to each other
- uses the design system pagination component for accessibility and maintainability (this should track upstream changes from the design system team)


- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes

Showing the first section in the application, this screen should only have the "Next" pagination.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_organisation_information](https://github.com/user-attachments/assets/6dfbcc2e-27c0-4d71-9984-b89493961ef4)

Showing a section in the middle of a group, this screen should have "Next" and "Previous" options within that group.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_applicant_information](https://github.com/user-attachments/assets/a786c51d-1c02-4015-813b-a04002e6b0a4)

Showing a section at the end of a group, this screen should have a "Next" option that takes you to the first section in the next group.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_environmental_sustainability](https://github.com/user-attachments/assets/88482765-f9ef-4102-80fc-d785c9beacf5)

Showing the final section of the last group, this screen should have a "Next" option that takes you back to the task list for the application.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_Representation_inclusiveness_%26_integration](https://github.com/user-attachments/assets/757174bb-e7cb-49ff-ba40-31278f07f10f)

