### PR TITLE
FS-4082 Show pagination uniformly on the scoring page

### DIFF
--- a/app/blueprints/assessments/templates/sub_criteria.html
+++ b/app/blueprints/assessments/templates/sub_criteria.html
@@ -89,19 +89,7 @@ Error:
                     {{ edit_comment_box(comments, comment_id, comment_form)}}
                 {% endif %}
 
-                {{ govukPagination({
-                    "previous": pagination.previous and {
-                        "labelText": pagination.previous.sub_section_name,
-                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.previous.sub_section_id)
-                    },
-                    "next": {
-                        "labelText": pagination.next.sub_section_name,
-                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.next.sub_section_id)
-                    } if pagination.next else {
-                        "labelText": "Back to assessment task list",
-                        "href": url_for("assessment_bp.application", application_id=application_id)
-                    }
-                }) }}
+                {% include "./components/sub_section_pagination.html" %}
         </div>
 </div>
 {% endblock content %}

--- a/app/blueprints/scoring/routes.py
+++ b/app/blueprints/scoring/routes.py
@@ -119,4 +119,5 @@ def score(
         assessment_status=assessment_status,
         is_flaggable=False,  # Flag button is disabled in sub-criteria page
         migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
+        pagination=state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     )

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -7,6 +7,8 @@
 {% from "macros/comments_summary.html" import comment_summary %}
 {% from "macros/sub_criteria_heading.html" import sub_criteria_heading %}
 {% from "macros/migration_banner.html" import migration_banner %}
+{%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
+
 {% set pageHeading -%}
 {% if score_form.errors.get('score') or score_form.errors.get('justification') %}
 Error:
@@ -59,6 +61,22 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
             {{ scores_justification(score_form, rescore_form, is_rescore, latest_score, application_id,
             sub_criteria.id,state.fund_guidance_url, score_list) }}
             {{ comment_summary(comments, sub_criteria.themes) }}
+
+            <div class="govuk-grid-column-full govuk-!-margin-top-4">
+                {{ govukPagination({
+                    "previous": pagination.previous and {
+                        "labelText": pagination.previous.sub_section_name,
+                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.previous.sub_section_id)
+                    },
+                    "next": {
+                        "labelText": pagination.next.sub_section_name,
+                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.next.sub_section_id)
+                    } if pagination.next else {
+                        "labelText": "Back to assessment task list",
+                        "href": url_for("assessment_bp.application", application_id=application_id)
+                    }
+                }) }}
+            </div>
         </div>
 </div>
 {% endblock content %}

--- a/app/blueprints/scoring/templates/score.html
+++ b/app/blueprints/scoring/templates/score.html
@@ -7,7 +7,6 @@
 {% from "macros/comments_summary.html" import comment_summary %}
 {% from "macros/sub_criteria_heading.html" import sub_criteria_heading %}
 {% from "macros/migration_banner.html" import migration_banner %}
-{%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
 
 {% set pageHeading -%}
 {% if score_form.errors.get('score') or score_form.errors.get('justification') %}
@@ -63,19 +62,7 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
             {{ comment_summary(comments, sub_criteria.themes) }}
 
             <div class="govuk-grid-column-full govuk-!-margin-top-4">
-                {{ govukPagination({
-                    "previous": pagination.previous and {
-                        "labelText": pagination.previous.sub_section_name,
-                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.previous.sub_section_id)
-                    },
-                    "next": {
-                        "labelText": pagination.next.sub_section_name,
-                        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.next.sub_section_id)
-                    } if pagination.next else {
-                        "labelText": "Back to assessment task list",
-                        "href": url_for("assessment_bp.application", application_id=application_id)
-                    }
-                }) }}
+                {% include "components/sub_section_pagination.html" %}
             </div>
         </div>
 </div>

--- a/app/blueprints/services/models/assessor_task_list.py
+++ b/app/blueprints/services/models/assessor_task_list.py
@@ -182,6 +182,6 @@ def get_page(index, sections):
     has_previous_elements = index > 0
     has_next_elements = index < len(sections) - 1
     return dict(
-        previous=has_previous_elements and sections[index - 1],
-        next=has_next_elements and sections[index + 1],
+        previous=sections[index - 1] if has_previous_elements else None,
+        next=sections[index + 1] if has_next_elements else None,
     )

--- a/app/templates/components/sub_section_pagination.html
+++ b/app/templates/components/sub_section_pagination.html
@@ -1,0 +1,15 @@
+{%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
+
+{{ govukPagination({
+    "previous": pagination.previous and {
+        "labelText": pagination.previous.sub_section_name,
+        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.previous.sub_section_id)
+    },
+    "next": {
+        "labelText": pagination.next.sub_section_name,
+        "href": url_for("assessment_bp.display_sub_criteria", application_id=application_id, sub_criteria_id=pagination.next.sub_section_id)
+    } if pagination.next else {
+        "labelText": "Back to assessment task list",
+        "href": url_for("assessment_bp.application", application_id=application_id)
+    }
+}) }}

--- a/tests/test_shared_helpers.py
+++ b/tests/test_shared_helpers.py
@@ -21,7 +21,7 @@ def test_pagination_helper_should_parse_with_real_backend_data(
     pagination = state.get_pagination_from_sub_criteria_id("test_sub_criteria_id")
 
     assert pagination["previous"]["sub_section_name"] == "A fixed sub criteria"
-    assert pagination["next"] is False
+    assert pagination["next"] is None
 
 
 def test_pagination_should_be_none_for_missing_section_id():
@@ -39,8 +39,8 @@ def test_pagination_should_be_empty_with_only_one_section():
         ],
     )
     pagination = state.get_pagination_from_sub_criteria_id("first-section")
-    assert pagination["previous"] is False
-    assert pagination["next"] is False
+    assert pagination["previous"] is None
+    assert pagination["next"] is None
 
 
 multiple_sections_state = mock_task_list(
@@ -95,7 +95,7 @@ def test_pagination_should_have_empty_previous_when_loading_first_section():
     pagination = multiple_sections_state.get_pagination_from_sub_criteria_id(
         "first-section"
     )
-    assert pagination["previous"] is False
+    assert pagination["previous"] is None
     assert pagination["next"]["sub_section_id"] == "second-section"
 
 
@@ -104,7 +104,7 @@ def test_pagination_should_have_empty_next_when_loading_last_section():
         "second-criteria-id"
     )
     assert pagination["previous"]["sub_section_id"] == "criteria-id"
-    assert pagination["next"] is False
+    assert pagination["next"] is None
 
 
 def test_pagination_should_have_previous_next_when_loading_within_section_group():


### PR DESCRIPTION
### Change description
Uniformly show the sub-section pagination component on the "scoring" page (either if the sub-section has already been scored or is it yet to be scored).

This would navigate to the default sub-section page (the top link on the left hand nav) to keep it consistent with the other pagination.

The sub section pagination is shared by the `scores` and `assessments` blueprints. As it relies on the a consistent helper model move it into a component that can be included by those separate templates.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)

The scoring sub-page with pagination before a score has been submitted.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_environmental_sustainability_score](https://github.com/user-attachments/assets/5efe199d-10c8-4fa3-9a17-a8bf0f404928)

The scoring sub-page with pagination after a score has been submitted.

![localhost_3010_assess_application_id_de1e8f9d-e4f6-447d-96e9-35b0ff58ef51_sub_criteria_id_environmental_sustainability_score (1)](https://github.com/user-attachments/assets/93889ba0-52fa-40ac-8f18-cdd1152d1d67)

