### PR TITLE
Implement ability to unassign assessors from applications

### DIFF
--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -68,9 +68,13 @@ class AssignmentOverviewForm(FlaskForm):
                 return False
 
             passed_validation = True
-            if not request.form.getlist("selected_users"):
-                self.form_errors.append("At least one assessor should be selected")
-                passed_validation = False
+            if set(request.form.getlist("assigned_users")) == set(
+                request.form.getlist("selected_users")
+            ):
+                self.form_errors.append(
+                    "No changes have been made to the current assignments for this application"
+                )
+                return False
 
             if not request.form.getlist("assessor_role"):
                 self.form_errors.append("An assessor type should be selected")

--- a/app/blueprints/assessments/templates/assignment_overview.html
+++ b/app/blueprints/assessments/templates/assignment_overview.html
@@ -36,8 +36,11 @@
             </p>
             {% else %}
             <p class="govuk-body">
-                You are about to assign <strong>{{ selected_user_names|join(', ') }}</strong> to {{ selected_assessments|length }} assessment{% if selected_assessments |length > 1 %}s{% endif %} as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor.
-                {# You are about to remove <strong>{{ remove_user }}</strong> from <strong>{{ assessment_count }}</strong> assessment{% if assessment_count > 1 %}s{% endif %} and assign <strong>{{ assign_user }}</strong> to the same assessment{% if assessment_count > 1 %}s{% endif %} as a general assessor. #}
+                You are about to {% if add_assign_user_names and not unassign_user_names %}assign <strong>{{ add_assign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor to the selected assessment.{% endif %}{% if unassign_user_names and not add_assign_user_names %}remove <strong>{{ unassign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor from the selected assessment.{% endif %}
+                {% if unassign_user_names and add_assign_user_names %}
+                <li class="govuk-body">assign <strong>{{ add_assign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor to the assessment</li>
+                <li class="govuk-body">remove <strong>{{ unassign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor from the assessment</li>
+                {% endif %}
             </p>
             {% endif %}
             <form method="post" action="{{ url_for('assessment_bp.assignment_overview',
@@ -57,6 +60,9 @@
             <input type="hidden" name="selected_assessments" value="{{ assessment }}">
             {% endfor %}
             <input type="hidden" name="assessor_role" value="{{ assessor_role }}">
+            {% for user_id in assigned_users %}
+            <input type="hidden" name="assigned_users" value="{{ user_id }}">
+            {% endfor %}
             {% for user in selected_users %}
             <input type="hidden" name="selected_users" value="{{ user }}">
             {% endfor %}

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -94,12 +94,13 @@ def call_search_applications(params: dict | str):
     return applications_response
 
 
-def get_application_assignments(application_id):
+def get_application_assignments(application_id, only_active=False):
     application_assignments_endpoint = Config.ASSESSMENT_ASSIGNED_USERS_ENDPOINT.format(
         application_id=application_id
     )
     current_app.logger.info(f"Endpoint '{application_assignments_endpoint}'.")
-    response = get_data(application_assignments_endpoint)
+    query_params = {"active": "true"} if only_active else {}
+    response = get_data(application_assignments_endpoint, query_params)
 
     return response if response is not None else []
 

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -11,6 +11,7 @@ class UnitTestConfig(DefaultConfig):
     DefaultConfig.TALISMAN_SETTINGS["force_https"] = False
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
     WTF_CSRF_ENABLED = False
+    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": True}
 
     # RSA 256 KEYS
     RSA256_PUBLIC_KEY_BASE64 = getenv("RSA256_PUBLIC_KEY_BASE64")


### PR DESCRIPTION
Lead assessors can now un-assign assessors who have been assigned applications. It is possible to assign and unassign different users to the same application in one go.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
