### PR TITLE
FS 4579 Email comments for assessors

### DIFF
--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -61,21 +61,24 @@ class AssessorChoiceForm(FlaskForm):
 
 
 class AssessorCommentForm(FlaskForm):
+    def __init__(self):
+        super().__init__()
+        self.message_errors = {}
+
     def validate(self, extra_validators=None):
         if super().validate(extra_validators):
             if request.referrer != request.url:
-                # From a redirect, not a form post
                 return False
 
-            # if set(request.form.getlist("assigned_users")) == set(
-            #     request.form.getlist("selected_users")
-            # ):
-            #     self.form_errors.append(
-            #         "No changes have been made to the current assignments for this application"
-            #     )
-            #     return False
+            passed_validation = True
+            for key, value in request.form.items():
+                if "message_" in key and len(value) > 2000:
+                    self.message_errors[key] = (
+                        "The message must be 2000 characters or less"
+                    )
+                    passed_validation = False
 
-            return True
+            return passed_validation
 
         return False
 

--- a/app/blueprints/assessments/forms/assignment_forms.py
+++ b/app/blueprints/assessments/forms/assignment_forms.py
@@ -60,6 +60,26 @@ class AssessorChoiceForm(FlaskForm):
         return False
 
 
+class AssessorCommentForm(FlaskForm):
+    def validate(self, extra_validators=None):
+        if super().validate(extra_validators):
+            if request.referrer != request.url:
+                # From a redirect, not a form post
+                return False
+
+            # if set(request.form.getlist("assigned_users")) == set(
+            #     request.form.getlist("selected_users")
+            # ):
+            #     self.form_errors.append(
+            #         "No changes have been made to the current assignments for this application"
+            #     )
+            #     return False
+
+            return True
+
+        return False
+
+
 class AssignmentOverviewForm(FlaskForm):
     def validate(self, extra_validators=None):
         if super().validate(extra_validators):

--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -3,6 +3,7 @@ import contextvars
 import functools
 import io
 import itertools
+import json
 import time
 import zipfile
 from collections import OrderedDict
@@ -23,6 +24,7 @@ from flask import url_for
 from fsd_utils import extract_questions_and_answers
 from fsd_utils.sqs_scheduler.context_aware_executor import ContextAwareExecutor
 from werkzeug.datastructures import ImmutableMultiDict
+from werkzeug.datastructures import MultiDict
 
 from app.blueprints.assessments.activity_trail import AssociatedTags
 from app.blueprints.assessments.activity_trail import CheckboxForm
@@ -36,6 +38,7 @@ from app.blueprints.assessments.activity_trail import select_filters
 from app.blueprints.assessments.forms.assessment_form import AssessmentCompleteForm
 from app.blueprints.assessments.forms.assignment_forms import AssessmentAssignmentForm
 from app.blueprints.assessments.forms.assignment_forms import AssessorChoiceForm
+from app.blueprints.assessments.forms.assignment_forms import AssessorCommentForm
 from app.blueprints.assessments.forms.assignment_forms import AssessorTypeForm
 from app.blueprints.assessments.forms.assignment_forms import AssignmentOverviewForm
 from app.blueprints.assessments.forms.comments_form import CommentsForm
@@ -706,6 +709,145 @@ def assessor_type_list(fund_short_name: str, round_short_name: str):
     )
 
 
+@assessment_bp.route(
+    "/assign/<fund_short_name>/<round_short_name>/assessors/comment",
+    methods=["GET", "POST"],
+)
+@check_access_fund_short_name_round_sn
+@check_access_fund_short_name_round_sn(roles_required=[Config.LEAD_ASSESSOR])
+def assessor_comments(fund_short_name: str, round_short_name: str):
+
+    if "cancel_messages" in request.form:
+        return redirect(
+            url_for(
+                "assessment_bp.assignment_overview",
+                fund_short_name=fund_short_name,
+                round_short_name=round_short_name,
+            ),
+            307,
+        )
+
+    assigned_user_set = set(request.form.getlist("assigned_users"))
+    selected_user_set = set(request.form.getlist("selected_users"))
+
+    if not (selected_assessments := request.form.getlist("selected_assessments")):
+        abort(500, "Required selected_assessments field to be populated")
+
+    if not (assessor_role := request.form.getlist("assessor_role")):
+        abort(500, "Required assessor_role field to be populated")
+
+    assessor_messages = {
+        key: value for key, value in request.form.items() if "message_" in key and value
+    }
+
+    assessor_role = assessor_role[0]
+
+    form = AssessorCommentForm()
+
+    if form.validate_on_submit():
+        return redirect(
+            url_for(
+                "assessment_bp.assignment_overview",
+                fund_short_name=fund_short_name,
+                round_short_name=round_short_name,
+            ),
+            307,
+        )
+
+    add_user_assignments = selected_user_set - assigned_user_set
+    remove_user_assignments = assigned_user_set - selected_user_set
+
+    fund = get_fund(
+        fund_short_name,
+        use_short_name=True,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+    if not fund:
+        return redirect(ASSESSMENT_TOOL_DASHBOARD_PATH)
+
+    round = get_round(
+        fund_short_name,
+        round_short_name,
+        use_short_name=True,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+
+    round_details = {
+        "assessment_deadline": round.assessment_deadline,
+        "round_title": round.title,
+        "fund_name": fund.name,
+        "fund_short_name": fund_short_name,
+        "round_short_name": round_short_name,
+        "is_expression_of_interest": round.is_expression_of_interest,
+    }
+
+    thread_executor = ContextAwareExecutor(
+        max_workers=4,
+        thread_name_prefix="assignment-overview-request",
+        flask_app=current_app,
+    )
+
+    future_all_applications_metadata = thread_executor.submit(
+        get_application_overviews, fund.id, round.id, ""
+    )
+
+    # Get all the users for the fund
+    future_users_for_fund = thread_executor.submit(
+        get_users_for_fund,
+        fund.short_name,
+        None,  # round_short_name,
+        True,
+        False,
+    )
+
+    all_applications_metadata = future_all_applications_metadata.result()
+    users_for_fund = future_users_for_fund.result()
+
+    thread_executor.executor.shutdown()
+
+    # Get either name or email of those assessors that have been selected
+    add_assign_users = (
+        [user for user in users_for_fund if user["account_id"] in add_user_assignments]
+        if users_for_fund
+        else []
+    )
+    add_assign_user_names = [
+        user["full_name"] if user["full_name"] else user["email_address"]
+        for user in add_assign_users
+    ]
+
+    unassign_users = (
+        [
+            user
+            for user in users_for_fund
+            if user["account_id"] in remove_user_assignments
+        ]
+        if users_for_fund
+        else []
+    )
+
+    unassign_user_names = [
+        user["full_name"] if user["full_name"] else user["email_address"]
+        for user in unassign_users
+    ]
+
+    unfiltered_stats = process_assessments_stats(all_applications_metadata)
+    return render_template(
+        "assessor_comments.html",
+        round_details=round_details,
+        stats=unfiltered_stats,
+        assessor_role=assessor_role,
+        add_assign_user_names=add_assign_user_names,
+        unassign_user_names=unassign_user_names,
+        changed_users=add_assign_users + unassign_users,
+        selected_assessments=selected_assessments,
+        selected_users=selected_user_set,
+        assigned_users=assigned_user_set,
+        assessor_messages=assessor_messages,
+        form=form,
+    )
+
+
 """
 View 4/4 in the assignment flow. This view displays the choices
 selected by the user in an overview form. The user can navigate
@@ -753,6 +895,28 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
             307,
         )
 
+    if "edit_messages" in request.form:
+        return redirect(
+            url_for(
+                "assessment_bp.assessor_comments",
+                fund_short_name=fund_short_name,
+                round_short_name=round_short_name,
+            ),
+            307,
+        )
+
+    if "cancel_messages" in request.form:
+        original_messages = json.loads(request.form["old_assessor_messages"])
+        new_request_form = MultiDict(request.form)
+        for key in request.form.keys():
+            if "message_" in key:
+                new_request_form.pop(key)
+
+        for key, value in original_messages.items():
+            new_request_form[key] = value
+
+        request.form = ImmutableMultiDict(new_request_form)
+
     assigned_user_set = set(request.form.getlist("assigned_users"))
     selected_user_set = set(request.form.getlist("selected_users"))
 
@@ -764,6 +928,10 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
 
     if assigned_user_set == selected_user_set:
         abort(500, "No change in assignments has been made")
+
+    assessor_messages = {
+        key: value for key, value in request.form.items() if "message_" in key and value
+    }
 
     add_user_assignments = selected_user_set - assigned_user_set
     remove_user_assignments = assigned_user_set - selected_user_set
@@ -960,6 +1128,7 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
         selected_users=selected_user_set,
         assigned_users=assigned_user_set,
         assessor_role=assessor_role,
+        assessor_messages=assessor_messages,
         round_details=round_details,
         stats=unfiltered_stats,
         assessments=post_processed_overviews,

--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -15,6 +15,7 @@ from flask import Blueprint
 from flask import Response
 from flask import abort
 from flask import current_app
+from flask import escape
 from flask import g
 from flask import redirect
 from flask import render_template
@@ -739,7 +740,16 @@ def assessor_comments(fund_short_name: str, round_short_name: str):
     assessor_messages = {}
     for key, value in request.form.items():
         if "message_" in key and value:
-            assessor_messages[key] = value
+            assessor_messages[key] = escape(value)
+
+    old_assessor_messages = (
+        json.loads(request.form.get("old_assessor_messages"))
+        if "old_assessor_messages" in request.form
+        else assessor_messages
+    )
+    has_individual_messages = any(
+        key != "message_to_all" for key in assessor_messages.keys()
+    )
 
     assessor_role = assessor_role[0]
 
@@ -844,7 +854,9 @@ def assessor_comments(fund_short_name: str, round_short_name: str):
         selected_assessments=selected_assessments,
         selected_users=selected_user_set,
         assigned_users=assigned_user_set,
+        old_assessor_messages=old_assessor_messages,
         assessor_messages=assessor_messages,
+        has_individual_messages=has_individual_messages,
         form=form,
     )
 
@@ -933,7 +945,7 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
     assessor_messages = {}
     for key, value in request.form.items():
         if "message_" in key and value:
-            assessor_messages[key] = value
+            assessor_messages[key] = escape(value)
 
     add_user_assignments = selected_user_set - assigned_user_set
     remove_user_assignments = assigned_user_set - selected_user_set

--- a/app/blueprints/assessments/templates/assessor_comments.html
+++ b/app/blueprints/assessments/templates/assessor_comments.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/tabs/macro.html' import govukTabs -%}
+{% import "macros/application_overviews_table_all.html" as application_overviews_table -%}
+{% import "macros/team_dashboard_header.html" as team_dashboard_header -%}
+{% from "macros/banner_summary.html" import banner_summary %}
+{% from "macros/logout_partial.html" import logout_partial %}
+{% from "macros/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}Team dashboard{% endset %}
+
+{% block header %}
+    {{ team_dashboard_header.render(round_details, stats, team_flag_stats, is_active_status) }}
+{% endblock header %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">Add a message</h1>
+
+  <p class="govuk-body">
+    You are about to {% if add_assign_user_names and not unassign_user_names %}assign <strong>{{ add_assign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor to the selected assessment.{% endif %}{% if unassign_user_names and not add_assign_user_names %}remove <strong>{{ unassign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor from the selected assessment.{% endif %}
+    {% if unassign_user_names and add_assign_user_names %}
+    <li class="govuk-body">assign <strong>{{ add_assign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor to the assessment</li>
+    <li class="govuk-body">remove <strong>{{ unassign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor from the assessment</li>
+    {% endif %}
+</p>
+<p class="govuk-body">
+  You can send a message to all selected assessors, and/or send separate notes to individual assessors.
+</p>
+<form method="post" action="{{ url_for('assessment_bp.assessor_comments',
+    fund_short_name=round_details.fund_short_name,
+    round_short_name=round_details.round_short_name) }}">
+    {{ form.csrf_token }}
+    {% if form.form_errors %}
+      <ul class="errors">
+      {% for error in form.form_errors %}
+          <p class="govuk-error-message">
+              <li>{{ error }}</li>
+          </p>
+      {% endfor %}
+      </ul>
+    {% endif %}
+    {% for assessment in selected_assessments %}
+      <input type="hidden" name="selected_assessments" value="{{ assessment }}">
+    {% endfor %}
+      <input type="hidden" name="assessor_role" value="{{ assessor_role }}">
+    {% for user_id in assigned_users %}
+      <input type="hidden" name="assigned_users" value="{{ user_id }}">
+    {% endfor %}
+    {% for user in selected_users %}
+      <input type="hidden" name="selected_users" value="{{ user }}">
+    {% endfor %}
+    <input type="hidden" name="old_assessor_messages" value="{{ assessor_messages | tojson | forceescape }}">
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="message_to_all">
+        Message to all assessors (optional)
+      </label>
+      <textarea class="govuk-textarea" id="message_to_all" name="message_to_all" rows="5">{{ assessor_messages["message_to_all"] if "message_to_all" in assessor_messages else "" }}</textarea>
+    </div>
+    {% if changed_users|length  > 1 %}
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="assessor_messages_checkbox" type="checkbox" name="assessor_messages">
+      <label class="govuk-label govuk-checkboxes__label" for="assessor_messages_checkbox">
+        Leave individual messages for assessors
+      </label>
+    </div>
+
+    {# djlint:off #}<div id="assessor_messages" class="govuk-form-group" style="display:none;">
+    {# djlint:on #}
+      {% for user in changed_users %}
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="label_{{ user["account_id"] }}">
+            Message to <strong>{{ user["full_name"] if user["full_name"] else user["email_address"] }}</strong> (optional)
+          </label>
+          <textarea class="govuk-textarea" id="message_{{ user["account_id"] }}" name="message_{{ user["account_id"] }}" rows="5">{{ assessor_messages["message_" + user["account_id"]] if ("message_" + user["account_id"]) in assessor_messages else "" }}</textarea>
+        </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    <button type="submit" class="govuk-button" data-module="govuk-button">
+      Save and continue
+    </button>
+    <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" name="cancel_messages" value="cancel_messages">
+      Cancel
+    </button>
+  </form>
+
+{% endblock content %}

--- a/app/blueprints/assessments/templates/assessor_comments.html
+++ b/app/blueprints/assessments/templates/assessor_comments.html
@@ -18,6 +18,23 @@
 {% block content %}
   <h1 class="govuk-heading-l">Add a message</h1>
 
+  {% if form.message_errors %}
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+<div role="alert">
+    <h2 class="govuk-error-summary__title">
+    There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+        {% for key, error in form.message_errors.items() %}
+        <li><a href="#{{ key }}">{{ error }}</a></li>
+        {% endfor %}
+    </ul>
+    </div>
+</div>
+</div>
+{% endif %}
+
   <p class="govuk-body">
     You are about to {% if add_assign_user_names and not unassign_user_names %}assign <strong>{{ add_assign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor to the selected assessment.{% endif %}{% if unassign_user_names and not add_assign_user_names %}remove <strong>{{ unassign_user_names|join(', ') }}</strong> as a {{ "lead" if assessor_role == "lead_assessor" else "general" }} assessor from the selected assessment.{% endif %}
     {% if unassign_user_names and add_assign_user_names %}
@@ -32,15 +49,6 @@
     fund_short_name=round_details.fund_short_name,
     round_short_name=round_details.round_short_name) }}">
     {{ form.csrf_token }}
-    {% if form.form_errors %}
-      <ul class="errors">
-      {% for error in form.form_errors %}
-          <p class="govuk-error-message">
-              <li>{{ error }}</li>
-          </p>
-      {% endfor %}
-      </ul>
-    {% endif %}
     {% for assessment in selected_assessments %}
       <input type="hidden" name="selected_assessments" value="{{ assessment }}">
     {% endfor %}
@@ -51,29 +59,40 @@
     {% for user in selected_users %}
       <input type="hidden" name="selected_users" value="{{ user }}">
     {% endfor %}
-    <input type="hidden" name="old_assessor_messages" value="{{ assessor_messages | tojson | forceescape }}">
-    <div class="govuk-form-group">
+    <input type="hidden" name="old_assessor_messages" value="{{ old_assessor_messages | tojson | forceescape }}">
+    <div class="govuk-form-group {% if "message_to_all" in form.message_errors %} govuk-form-group--error {% endif %}">
       <label class="govuk-label" for="message_to_all">
         Message to all assessors (optional)
       </label>
+        {% if "message_to_all" in form.message_errors %}
+        <p class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ form.message_errors["message_to_all"] }}
+        </p>
+        {% endif %}
       <textarea class="govuk-textarea" id="message_to_all" name="message_to_all" rows="5">{{ assessor_messages["message_to_all"] if "message_to_all" in assessor_messages else "" }}</textarea>
     </div>
     {% if changed_users|length  > 1 %}
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="assessor_messages_checkbox" type="checkbox" name="assessor_messages">
+      <input class="govuk-checkboxes__input" id="assessor_messages_checkbox" type="checkbox" name="assessor_messages" {% if has_individual_messages %}checked{% endif %}>
       <label class="govuk-label govuk-checkboxes__label" for="assessor_messages_checkbox">
         Leave individual messages for assessors
       </label>
     </div>
     <div>
-    {# djlint:off #}<div id="assessor_messages" class="govuk-form-group govuk-!-display-none">
+    {# djlint:off #}<div id="assessor_messages" class="govuk-form-group {% if has_individual_messages %}govuk-!-display-block{% else %}govuk-!-display-none{% endif %}">
     {# djlint:on #}
       {% for user in changed_users %}
-        <div class="govuk-form-group">
+        {% set message_id = "message_" + user['account_id'] %}
+        <div class="govuk-form-group {% if message_id in form.message_errors %} govuk-form-group--error {% endif %}">
           <label class="govuk-label" for="label_{{ user["account_id"] }}">
             Message to <strong>{{ user["full_name"] if user["full_name"] else user["email_address"] }}</strong> (optional)
           </label>
-          <textarea class="govuk-textarea" id="message_{{ user["account_id"] }}" name="message_{{ user["account_id"] }}" rows="5">{{ assessor_messages["message_" + user["account_id"]] if ("message_" + user["account_id"]) in assessor_messages else "" }}</textarea>
+            {% if message_id in form.message_errors %}
+            <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ form.message_errors[message_id] }}
+            </p>
+            {% endif %}
+          <textarea class="govuk-textarea" id="{{ message_id }}" name="{{ message_id }}" rows="5">{{ assessor_messages[message_id] if message_id in assessor_messages else "" }}</textarea>
         </div>
       {% endfor %}
     </div>

--- a/app/blueprints/assessments/templates/assessor_comments.html
+++ b/app/blueprints/assessments/templates/assessor_comments.html
@@ -65,8 +65,8 @@
         Leave individual messages for assessors
       </label>
     </div>
-
-    {# djlint:off #}<div id="assessor_messages" class="govuk-form-group" style="display:none;">
+    <div>
+    {# djlint:off #}<div id="assessor_messages" class="govuk-form-group govuk-!-display-none">
     {# djlint:on #}
       {% for user in changed_users %}
         <div class="govuk-form-group">
@@ -77,6 +77,7 @@
         </div>
       {% endfor %}
     </div>
+  </div>
     {% endif %}
 
     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/app/blueprints/assessments/templates/assignment_overview.html
+++ b/app/blueprints/assessments/templates/assignment_overview.html
@@ -68,6 +68,9 @@
             {% for user in selected_users %}
             <input type="hidden" name="selected_users" value="{{ user }}">
             {% endfor %}
+            {% for key, value in assessor_messages.items() %}
+            <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endfor %}
             <p class="govuk-body">
                 <button type="submit" class="govuk-link btn-link" name="change_roles" value="change_roles">Change roles</button> or
                 <button type="submit" class="govuk-link btn-link" name="change_users" value="change_users">Change users</button>
@@ -111,6 +114,7 @@
             </table>
             <button type="submit" class="govuk-link btn-link" name="change_assessments" value="change_assessments">Add/remove assessments</button>
     </div>
+        <button type="submit" class="govuk-link btn-link" name="edit_messages" value="edit_messages">Add messages</button>
             {#
             <div class="govuk-form-group">
                 <label class="govuk-label" for="message">Message to assessors assigned (optional)</label>

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -863,6 +863,8 @@ def assign_user_to_assessment(
     assigner_id: str,
     update: Optional[bool] = False,
     active: Optional[bool] = True,
+    send_email: Optional[bool] = False,
+    email_content: Optional[str] = None,
 ):
     """Creates a user association between a user and an application.
     Internally, this is how we assign a user to an assessment.
@@ -872,16 +874,19 @@ def assign_user_to_assessment(
     :param assigner_id: The id of the user who is creating the assignment
     :param update: update assignment if it already exists
     :param active: Whether or not to mark the assignment as active (only used if update is True)
+    :param send_email: If an email notification should be sent when the (un)assignment is processed
+    :param email_content: Custom message to be sent by email (only applicable if send_email is True)
     """
     assignment_endpoint = Config.ASSESSMENT_ASSOCIATE_USER_ENDPOINT.format(
         application_id=application_id, user_id=user_id
     )
+    json_body = {"active": active, "send_email": send_email, "assigner_id": assigner_id}
+    if email_content:
+        json_body["email_content"] = email_content
     if update:
-        response = requests.put(
-            assignment_endpoint, json={"active": "true" if active else "false"}
-        )
+        response = requests.put(assignment_endpoint, json=json_body)
     else:
-        response = requests.post(assignment_endpoint, json={"assigner_id": assigner_id})
+        response = requests.post(assignment_endpoint, json=json_body)
     if not response.ok:
         current_app.logger.error(
             f"Could not get assign user {user_id} to application {application_id}"

--- a/app/static/src/js/helpers.js
+++ b/app/static/src/js/helpers.js
@@ -91,11 +91,13 @@ if (select_all_users) {
 const assessor_messages_checkbox = document.getElementById('assessor_messages_checkbox')
 if (assessor_messages_checkbox) {
   assessor_messages_checkbox.addEventListener('change', function() {
-    var individualMessages = document.getElementById('assessor_messages');
-    if(this.checked) {
-      individualMessages.style.display = 'block';
-    } else {
-      individualMessages.style.display = 'none';
-    }
+    const messagesDiv = document.getElementById('assessor_messages');
+    if (assessor_messages_checkbox.checked) {
+      messagesDiv.classList.remove('govuk-!-display-none');
+      messagesDiv.classList.add('govuk-!-display-block');
+  } else {
+      messagesDiv.classList.add('govuk-!-display-none');
+      messagesDiv.classList.remove('govuk-!-display-block');
+  }
   });
 }

--- a/app/static/src/js/helpers.js
+++ b/app/static/src/js/helpers.js
@@ -87,3 +87,15 @@ if (select_all_users) {
     });
   });
 }
+
+const assessor_messages_checkbox = document.getElementById('assessor_messages_checkbox')
+if (assessor_messages_checkbox) {
+  assessor_messages_checkbox.addEventListener('change', function() {
+    var individualMessages = document.getElementById('assessor_messages');
+    if(this.checked) {
+      individualMessages.style.display = 'block';
+    } else {
+      individualMessages.style.display = 'none';
+    }
+  });
+}


### PR DESCRIPTION
### Change description
This PR covers the page and functionality to allow users to specify a custom message for the email notifications that are sent when assignments are made. It is dependent on changes in the assessment store and notification. 

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
There are 3 scenarios to check in the work allocation flow for both assignment and unassignment :
- No messages are provided 
- Message to all assignees is provided
- Messages to individual assignees are provided 

An email should be sent in all cases, and where a message is provided, it should also appear in the email
### Screenshots of UI changes (if applicable)
<img width="1318" alt="Screenshot 2024-09-17 at 14 56 19" src="https://github.com/user-attachments/assets/5d0db267-1e73-4af7-b995-463b6e07b388">
