### PR TITLE
FS-4579: Fix layout issues and display status of assessments

### DIFF
--- a/app/blueprints/assessments/routes.py
+++ b/app/blueprints/assessments/routes.py
@@ -1167,6 +1167,7 @@ def assignment_overview(fund_short_name: str, round_short_name: str):
         stats=unfiltered_stats,
         assessments=post_processed_overviews,
         form=form,
+        assessment_statuses=assessment_statuses,
     )
 
 

--- a/app/blueprints/assessments/templates/assignment_overview.html
+++ b/app/blueprints/assessments/templates/assignment_overview.html
@@ -8,6 +8,7 @@
 {% from "macros/banner_summary.html" import banner_summary %}
 {% from "macros/logout_partial.html" import logout_partial %}
 {% from "macros/migration_banner.html" import migration_banner %}
+{% from "macros/application_status_column.html" import application_status_column %}
 
 {% set pageHeading %}Team dashboard{% endset %}
 
@@ -97,7 +98,7 @@
                             overview.project_name }}</a></td>
                         <td class="govuk-table__cell">£{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
                         <td class="govuk-table__cell">{{ overview.location_json_blob.get('country') or "Not found" }}</td>
-                        <td class="govuk-table__cell">{{ "TODO" }}</td>
+                        {{ application_status_column(overview.application_status, overview.get("progress", ""), assessment_statuses) }}
                         <td class="govuk-table__cell">
                             {% if overview.assigned_to_names %}
                             {% for name in overview.assigned_to_names %}
@@ -114,13 +115,10 @@
             </table>
             <button type="submit" class="govuk-link btn-link" name="change_assessments" value="change_assessments">Add/remove assessments</button>
     </div>
-        <button type="submit" class="govuk-link btn-link" name="edit_messages" value="edit_messages">Add messages</button>
-            {#
-            <div class="govuk-form-group">
-                <label class="govuk-label" for="message">Message to assessors assigned (optional)</label>
-                <textarea class="govuk-textarea" id="message" name="message" rows="3">{{ message }}</textarea>
-            </div>
-            #}
+    <div class="govuk-form-group">
+        <p class="govuk-body"> {{ "Your message will be emailed to the assessor." if assessor_messages else "You have not added a message for this assignment change." }} </p>
+             <button type="submit" class="govuk-link btn-link" name="edit_messages" value="edit_messages">{{ "View or change message" if assessor_messages else "Add a message" }}</button>
+    </div>
             <button class="govuk-button" type="submit">Assign assessments</button>
         </form>
     </section>


### PR DESCRIPTION
### Change description
Minor UI fixes for FS-4579 including:
- Formatting of the 'Add messages button'
- Missing hint text to indicate whether or not messages have been added in the overview screen
- Display status of assessments selected for assignment

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
<img width="1260" alt="Screenshot 2024-09-24 at 11 38 27" src="https://github.com/user-attachments/assets/a33c1b78-2f5f-4dc4-bc17-4a3f8f3d6046">
