### PR TITLE
Removing list of fund short codes

### DIFF
--- a/app/blueprints/assessments/templates/activity_trail.html
+++ b/app/blueprints/assessments/templates/activity_trail.html
@@ -43,7 +43,8 @@
     funding_amount,
     assessment_status,
     flag_status,
-    display_status=False
+    display_status=False,
+    is_eoi_round=state.is_eoi_round
     ) }}
 </header>
 {% endblock header %}

--- a/app/blueprints/assessments/templates/assessor_tasklist.html
+++ b/app/blueprints/assessments/templates/assessor_tasklist.html
@@ -32,7 +32,6 @@
             {{ logout_partial(sso_logout_url) }}
         </div>
     </nav>
-
     {{ banner_summary(
         state.fund_name,
         state.fund_short_name,
@@ -40,7 +39,8 @@
         state.project_name,
         state.funding_amount_requested,
         assessment_status,
-        flag_status
+        flag_status,
+        is_eoi_round=state.is_eoi_round
     ) }}
 </header>
 {% endblock header %}

--- a/app/blueprints/assessments/templates/view_entire_application.html
+++ b/app/blueprints/assessments/templates/view_entire_application.html
@@ -25,7 +25,8 @@
     state.short_id,
     state.project_name,
     state.funding_amount_requested,
-    display_status=False
+    display_status=False,
+    is_eoi_round=state.is_eoi_round
     ) }}
 </header>
 {% endblock header %}

--- a/app/blueprints/services/data_services.py
+++ b/app/blueprints/services/data_services.py
@@ -5,6 +5,7 @@ from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Union
 from urllib.parse import urlencode
 
@@ -23,6 +24,7 @@ from app.blueprints.services.models.flag import FlagType
 from app.blueprints.services.models.fund import Fund
 from app.blueprints.services.models.round import Round
 from app.blueprints.services.models.sub_criteria import SubCriteria
+from app.blueprints.shared.helpers import get_ttl_hash
 from app.blueprints.tagging.models.tag import AssociatedTag
 from app.blueprints.tagging.models.tag import Tag
 from app.blueprints.tagging.models.tag import TagType
@@ -292,6 +294,11 @@ def get_funds(ttl_hash=None) -> Union[List[Fund], None]:
         "Error retrieving funds from fund store, please check this."
     )
     return []
+
+
+def get_all_fund_short_codes() -> Set[str]:
+    all_funds = get_funds(get_ttl_hash(seconds=Config.LRU_CACHE_TIME))
+    return {fund.short_name for fund in all_funds} if all_funds else {}
 
 
 @lru_cache(maxsize=1)

--- a/app/blueprints/services/models/assessor_task_list.py
+++ b/app/blueprints/services/models/assessor_task_list.py
@@ -51,6 +51,7 @@ class AssessorTaskList:
     fund_id: str
     round_id: str
     fund_guidance_url: str
+    is_eoi_round: str
 
     @classmethod
     def from_json(cls, json: dict):
@@ -102,6 +103,7 @@ class AssessorTaskList:
                 )
                 for criteria in json["criterias"]
             ],
+            is_eoi_round=json.get("is_eoi_round"),
         )
 
     def get_sub_sections_metadata(self) -> List[Dict]:

--- a/app/blueprints/services/models/fund.py
+++ b/app/blueprints/services/models/fund.py
@@ -29,12 +29,10 @@ class Fund:
             owner_organisation_logo_uri=data.get("owner_organisation_logo_uri"),
         )
 
-    # TODO: Move this config to database
+    # TODO: Move fund_type to a property on fund_store
     @property
     def fund_types(self) -> set[str]:
-        if self.short_name in ("COF", "NSTF", "CYP", "DPIF", "COF-EOI", "HSRA"):
-            return {ALL_VALUE, "competitive"}
-        return {ALL_VALUE}
+        return {ALL_VALUE, "competitive"}
 
     def add_round(self, fund_round: Round):
         if not self.rounds:

--- a/app/blueprints/services/shared_data_helpers.py
+++ b/app/blueprints/services/shared_data_helpers.py
@@ -21,5 +21,7 @@ def get_state_for_tasklist_banner(application_id) -> AssessorTaskList:
     assessor_task_list_metadata["fund_short_name"] = fund.short_name
     assessor_task_list_metadata["round_short_name"] = round.short_name
     assessor_task_list_metadata["fund_guidance_url"] = round.guidance_url
+    assessor_task_list_metadata["is_eoi_round"] = round.is_expression_of_interest
+
     state = AssessorTaskList.from_json(assessor_task_list_metadata)
     return state

--- a/app/templates/components/header.html
+++ b/app/templates/components/header.html
@@ -19,6 +19,7 @@
         sub_criteria.project_name if sub_criteria else state.project_name,
         sub_criteria.funding_amount_requested if sub_criteria else state.funding_amount_requested,
         assessment_status,
-        flag_status
+        flag_status,
+        is_eoi_round=state.is_eoi_round
     ) }}
 </header>

--- a/app/templates/macros/banner_summary.html
+++ b/app/templates/macros/banner_summary.html
@@ -1,4 +1,4 @@
-{% macro banner_summary(fund_name, fund_shortname, project_reference, project_name, funding_amount_requested, assessment_status, flag_status, display_status=True) %}
+{% macro banner_summary(fund_name, fund_shortname, project_reference, project_name, funding_amount_requested, assessment_status, flag_status, display_status=True, is_eoi_round=False) %}
 
 <div class="fsd-banner-background">
 <div class="govuk-width-container">
@@ -7,14 +7,14 @@
                 <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
                     <p class="govuk-heading-xl fsd-banner-content">Fund: <span class="govuk-!-font-weight-regular">{{ fund_name }}</span></p>
                     <p class="govuk-heading-l fsd-banner-content">Project reference: <span class="govuk-!-font-weight-regular">{{ project_reference | format_project_ref }}</span></p>
-                    {% set project_name_caption = "Project name:" if fund_shortname not in ["COF-EOI"] else "Organisation name:" %}
+                    {% set project_name_caption = "Project name:" if not is_eoi_round else "Organisation name:" %}
                     <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding">{{ project_name_caption }}&nbsp;{{ project_name }}</p>
-                    {% if fund_shortname not in ["DPIF", "COF-EOI"] %} {# Funds that should hide total funding requested. #}
+                    {% if fund_shortname not in ["DPIF"] and not is_eoi_round %} {# Funds that should hide total funding requested. #}
                         <p class="govuk-body-l fsd-banner-content ">Total funding requested: £{{ "{:,.2f}".format(funding_amount_requested | float) }}</p>
                     {% endif %}
 
                     {% if g.access_controller.has_any_assessor_role and display_status %}
-                        {% if fund_shortname.upper() != "COF-EOI" %}<strong class="govuk-tag govuk-tag--grey govuk-!-margin-top-4">{{ assessment_status }}</strong>{% endif %}
+                        {% if not is_eoi_round %}<strong class="govuk-tag govuk-tag--grey govuk-!-margin-top-4">{{ assessment_status }}</strong>{% endif %}
                         {% if "Flagged" in flag_status or flag_status in ["Multiple flags to resolve", "Stopped", "Flagged"] %}
                             <p class="govuk-body-l fsd-banner-content fsd-banner-collapse-padding govuk-!-margin-top-3">{{ flag_status or "" }}</p>
                         {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -723,6 +723,7 @@ def mock_get_tasklist_state_for_banner(mocker):
         project_reference="ABGCDF",
         sections=[],
         criterias=[],
+        is_eoi_round=False,
     )
     mocker.patch(
         "app.blueprints.assessments.routes.get_state_for_tasklist_banner",

--- a/tests/test_data_operations.py
+++ b/tests/test_data_operations.py
@@ -1,9 +1,12 @@
+import pytest
 from flask import Flask
 
+from app.blueprints.services.data_services import get_all_fund_short_codes
 from app.blueprints.services.data_services import get_application_overviews
 from app.blueprints.services.data_services import get_comments
 from app.blueprints.services.data_services import get_fund
 from app.blueprints.services.data_services import get_round
+from app.blueprints.services.models.fund import Fund
 from tests.api_data.test_data import mock_api_results
 
 
@@ -100,3 +103,29 @@ class TestDataOperations:
             comments = get_comments(*args)
         assert 5 == len(comments), "wrong number of comments"
         assert all(arg in get_data_mock.call_args.args[0] for arg in args)
+
+
+@pytest.mark.parametrize(
+    "mock_get_all_funds_response,exp_result",
+    [
+        (
+            [Fund(short_name="F1", id="id", description="hello fund", name="Fund 1")],
+            {"F1"},
+        ),
+        (
+            [
+                Fund(short_name="F1", id="id", description="hello fund", name="Fund 1"),
+                Fund(short_name="F2", id="id", description="hello fund", name="Fund 2"),
+            ],
+            {"F1", "F2"},
+        ),
+        ({}, {}),
+    ],
+)
+def test_get_all_fund_short_codes(mock_get_all_funds_response, exp_result, mocker):
+    mocker.patch(
+        "app.blueprints.services.data_services.get_funds",
+        return_value=mock_get_all_funds_response,
+    )
+    result = get_all_fund_short_codes()
+    assert result == exp_result


### PR DESCRIPTION
### Change description
Fixing anything in assessment with hard coded references to EOI - FS-4674
- Remove hard coded list of fund short codes that was determining what fund_type to use. Changed this to retrieve the list of all fund codes from fund-store so new funds will just work. (When we add `fund_type` as a specific configuration value on fund store, this needs changing to use that)
- Updating `banner_summary` macro to use the existing configuration value 'is_expression_of_interest' from the round rather than `if short_name=='COF-EOI':`

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
