### PR TITLE
Populate stats for cof eoi when applications are closed

### DIFF
--- a/app/blueprints/assessments/models/round_summary.py
+++ b/app/blueprints/assessments/models/round_summary.py
@@ -190,6 +190,8 @@ def create_round_summaries(fund: Fund, filters: LandingFilters) -> list[RoundSum
 
         if round_status.is_application_open:
             live_rounds.append(round)
+        elif round.is_expression_of_interest:
+            live_rounds.append(round)
 
         if round_status.is_application_not_yet_open:
             sorting_date = round.assessment_deadline


### PR DESCRIPTION

### Change description
The stats for COF-EOI in the assessor_tool_dashboard were not displaying when the applications were closed. This fix corrects the logic in create_round_summaries to fix that. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![Screenshot 2024-09-27 at 10 58 48](https://github.com/user-attachments/assets/d08a079e-6b0a-4509-b99b-6fa75b35b6cb)
<img width="430" alt="Screenshot 2024-10-04 at 16 52 21" src="https://github.com/user-attachments/assets/ed31b5d1-7d74-4598-8925-0e24c30eb2e5">
