### PR TITLE
Update support email to communities from levellingup

### DIFF
--- a/app/blueprints/shared/routes.py
+++ b/app/blueprints/shared/routes.py
@@ -34,6 +34,6 @@ def get_help():
         "get_help.html",
         # TODO: this contact information is for the round, so different email.
         # contact_details=round_data.get('contact_details'),
-        contact_details={"email_address": "FSD.Support@levellingup.gov.uk"},
+        contact_details={"email_address": "fundingservice.support@communities.gov.uk"},
         support_availability=round_data.get("support_availability"),
     )

--- a/app/blueprints/shared/templates/index.html
+++ b/app/blueprints/shared/templates/index.html
@@ -21,7 +21,7 @@
                     "text": "Log in"
                     }) }}
                     <h2 class="govuk-heading-l">Get help</h2>
-                    <p class="govuk-body">If you are having issues logging in, email the FSD support team at <a class="govuk-link" href="mailto:FSD.Support@levellingup.gov.uk">FSD.Support@levellingup.gov.uk</a></p>
+                    <p class="govuk-body">If you are having issues logging in, email the FSD support team at <a class="govuk-link" href="mailto:fundingservice.support@communities.gov.uk">fundingservice.support@communities.gov.uk</a></p>
                 </div>
             </div>
         </div>

--- a/app/templates/maintenance.html
+++ b/app/templates/maintenance.html
@@ -14,7 +14,7 @@
           <p class="govuk-body">We are carrying out essential maintenance to the funding assessment tool.</p>
           <p class="govuk-body">You will be able to use the service again {{ "on "+ maintenance_end_time if maintenance_end_time else "soon" }}.</p>
           <p class="govuk-body">
-            <a class="govuk-link" href="mailto:fsd.support@levellingup.gov.uk">Contact the Funding Service Design team</a> if you need urgent support during this time.
+            <a class="govuk-link" href="mailto:fundingservice.support@communities.gov.uk">Contact the Funding Service Design team</a> if you need urgent support during this time.
           </p>
         </div>
       </div>


### PR DESCRIPTION
### Change description
The old support email was using the levellingup domain ( [fsd.support@levellingup.gov.uk](mailto:fsd.support@levellingup.gov.uk) ). This has been updated to fundingservice.support@communities.gov.uk


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
