### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,7 +2,7 @@
 deepdiff
 invoke
 pip-tools>=6.13.0
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -221,8 +221,6 @@ idna==3.8
     #   email-validator
     #   httpx
     #   requests
-importlib-metadata==8.4.0
-    # via build
 inflection==0.5.1
     # via
     #   -r requirements.txt
@@ -330,7 +328,7 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements-dev.in
 pycodestyle==2.12.1
     # via flake8
@@ -582,8 +580,6 @@ wtforms==3.1.2
     #   flask-wtf
 xhtml2pdf==0.2.16
     # via -r requirements.txt
-zipp==3.20.1
-    # via importlib-metadata
 zstandard==0.23.0
     # via
     #   -r requirements.txt


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.