### PR TITLE
adding theme list for ctdf

### DIFF
--- a/config/themes_mapping.py
+++ b/config/themes_mapping.py
@@ -161,3 +161,5 @@ def ordered_themes(fund_round_short_name):
             "designated_area_details",
             "milestones",
         ]
+    if fund_round_short_name == "CTDFCR1":
+        return ["project_name", "organisation_name"]


### PR DESCRIPTION
Adding themes configuration for the crash test dummy fund to enable the 'view whole application' page in assessment