### PR TITLE
Turn off recreate deployments in test env

### DIFF
--- a/copilot/fsd-assessment/manifest.yml
+++ b/copilot/fsd-assessment/manifest.yml
@@ -85,8 +85,6 @@ environments:
         path: /healthcheck
         port: 8080
   test:
-    deployment:
-      rolling: "recreate"
     count:
       spot: 2
     sidecars:


### PR DESCRIPTION
This is because the `recreate` deployment method leads to downtime, which can cause tests to flake. It is not any faster than a normal deployment, and causes tests to break. I am not sure why it was chosen to begin with.

https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#deployment-rolling